### PR TITLE
Slwbuild/add more table mapping types

### DIFF
--- a/adx/config.go
+++ b/adx/config.go
@@ -2,6 +2,7 @@ package adx
 
 import (
 	"context"
+	"sync"
 
 	"github.com/Azure/azure-kusto-go/kusto"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -17,6 +18,7 @@ type Config struct {
 
 type Meta struct {
 	KustoClientsMap      map[string]*kusto.Client
+	KustoClientsMapMU    sync.RWMutex
 	DefaultClusterConfig *ClusterConfig
 	StopContext          context.Context
 }

--- a/adx/resource_adx_table_mapping_test.go
+++ b/adx/resource_adx_table_mapping_test.go
@@ -10,7 +10,7 @@ import (
 
 type ADXTableMappingTestResource struct{}
 
-func TestAccTableMapping_basic(t *testing.T) {
+func TestAccTableMapping_basicJson(t *testing.T) {
 	var entity TableMapping
 	r := ADXTableMappingTestResource{}
 	rtcBuilder := BuildResourceTestContext[TableMapping]()
@@ -31,7 +31,7 @@ func TestAccTableMapping_basic(t *testing.T) {
 		CheckDestroy: rtc.GetTestCheckEntityDestroyed(),
 		Steps: []resource.TestStep{
 			{
-				Config: r.basic(rtc),
+				Config: r.basicJson(rtc),
 				Check: resource.ComposeTestCheckFunc(
 					rtc.GetTestCheckEntityExists(&entity),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "name", rtc.EntityName),
@@ -47,7 +47,80 @@ func TestAccTableMapping_basic(t *testing.T) {
 	})
 }
 
-func (this ADXTableMappingTestResource) basic(rtc *ResourceTestContext[TableMapping]) string {
+func TestAccTableMapping_basicCsv(t *testing.T) {
+	var entity TableMapping
+	r := ADXTableMappingTestResource{}
+	rtcBuilder := BuildResourceTestContext[TableMapping]()
+	rtc, _ := rtcBuilder.Test(t).Type("adx_table_mapping").
+		DatabaseName("test-db").
+		EntityType("tablemapping").
+		ReadStatementFunc(func(id string) (string, error) {
+			mappingId, err := parseADXTableMappingID(id)
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf(".show table %s ingestion %s mapping '%s'", mappingId.Name, strings.ToLower(mappingId.Kind), mappingId.MappingName), nil
+		}).Build()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: rtc.GetTestCheckEntityDestroyed(),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basicCsv(rtc),
+				Check: resource.ComposeTestCheckFunc(
+					rtc.GetTestCheckEntityExists(&entity),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "name", rtc.EntityName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "table_name", "MappingTest1"),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "kind", "csv"),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "mapping.0.column", "f1"),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "mapping.0.ordinal", "1"),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "mapping.1.path", ""),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "mapping.1.ordinal", "2"),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "mapping.1.column", "f2"),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "mapping.2.datatype", "int"),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "mapping.3.ordinal", ""),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "mapping.3.constvalue", "constant_value"),
+				),
+			},
+		},
+	})
+}
+
+func (this ADXTableMappingTestResource) basicCsv(rtc *ResourceTestContext[TableMapping]) string {
+	return fmt.Sprintf(`
+	%s
+
+	resource "%s" "%s" {
+		name          = "%s"
+		database_name = "%s"
+		table_name    = adx_table.%s.name
+		kind          = "csv"
+		mapping {
+		  column   = "f1"
+		  ordinal  = "1"
+		  datatype = "string"
+		}
+		mapping {
+		  column   = "f2"
+		  ordinal  = "2"
+		}
+		mapping {
+		  column   = "f3"
+	      ordinal  = "3"
+		  datatype = "int"
+		}
+		mapping {
+		  column     = "f4"
+		  constvalue = "constant_value"
+		}
+	  }
+	`, this.template(rtc), rtc.Type, rtc.Label, rtc.EntityName, rtc.DatabaseName, rtc.Label)
+}
+
+func (this ADXTableMappingTestResource) basicJson(rtc *ResourceTestContext[TableMapping]) string {
 	return fmt.Sprintf(`
 	%s
 
@@ -80,7 +153,7 @@ func (this ADXTableMappingTestResource) template(rtc *ResourceTestContext[TableM
 	resource "adx_table" "%s" {
 		database_name = "%s"
 		name          = "MappingTest1"
-		table_schema  = "f1:string,f2:string,f3:int"
+		table_schema  = "f1:string,f2:string,f3:int,f4:string"
 	}
 	`, rtc.Label, rtc.DatabaseName)
 }

--- a/docs/resources/adx_table_mapping.md
+++ b/docs/resources/adx_table_mapping.md
@@ -9,6 +9,8 @@ description: |-
 
 Manages a table mapping in ADX.
 
+[ADX - Data Mappings](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/management/mappings)
+
 ## Example Usage
 
 ```terraform
@@ -41,18 +43,21 @@ resource "adx_table_mapping" "test" {
 - **name** (String, Required) Name of the Table mapping to create.
 - **database_name** (String, Required) Database name in which this Table mapping should be created.
 - **table_name** (String, Required) Table name in which this mapping should be created.
-- **kind** (String, Required) Mapping kind. The only currently supported value is `Json`.
+- **kind** (String, Required) Mapping kind. (json, csv, orc, avro, parquet, w3clogfile)
 - **mapping** A `mapping` block defined below.
 - **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
 
 `mapping` Configures a mapping and supports the following:
 
 - **column** (String, Required)
-- **path** (String, Required)
-- **datatype** (String, Required)
+- **path** (String, Optional)
+- **ordinal** (String, Optional)
+- **field** (String, Optional)
+- **constvalue** (String, Optional)
+- **datatype** (String, Optional)
 - **transform** (String, Optional)
 
-`cluster` Configuration block for connection details about the target ADX cluster 
+`cluster` Configuration block for connection details about the target ADX cluster
 
 *Note*: Any attributes specified here override the cluster config specified in the provider. Once a resource overrides an attribute specified in the provider, it will be stored explicitly as state for that resource and will not be possible to go back to the provider config unless explicitly unset.
 


### PR DESCRIPTION
# Add table mapping types (and updated acceptance tests)

* csv
* parquet
* avro
* orc
* w3clogfile

## Acceptance Tests
```
$ TF_ACC=1 go test -v ./adx
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccADXFunction_basic
--- PASS: TestAccADXFunction_basic (2.49s)
=== RUN   TestAccADXTableCachingPolicy_basic
--- PASS: TestAccADXTableCachingPolicy_basic (2.24s)
=== RUN   TestAccADXTableIngestionBatchingPolicy_basic
--- PASS: TestAccADXTableIngestionBatchingPolicy_basic (2.24s)
=== RUN   TestAccTableMapping_basicJson
--- PASS: TestAccTableMapping_basicJson (2.17s)
=== RUN   TestAccTableMapping_basicCsv
--- PASS: TestAccTableMapping_basicCsv (2.19s)
=== RUN   TestAccADXTablePartitioningPolicy_basic
--- PASS: TestAccADXTablePartitioningPolicy_basic (5.68s)
PASS
ok  	github.com/favoretti/terraform-provider-adx/adx	17.263s
```