### PR TITLE
Slwbuild/attached database policies

### DIFF
--- a/adx/resource_adx_materialized_view.go
+++ b/adx/resource_adx_materialized_view.go
@@ -95,6 +95,12 @@ func resourceADXMaterializedView() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+
+			"allow_mv_without_rls": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 		CustomizeDiff: clusterConfigCustomDiff,
 	}
@@ -125,6 +131,9 @@ func resourceADXMaterializedViewCreateUpdate(ctx context.Context, d *schema.Reso
 
 	if backfill, ok := d.GetOk("backfill"); ok {
 		withParams = append(withParams, fmt.Sprintf("backfill=%t", backfill.(bool)))
+	}
+	if allowMVWithoutRLS, ok := d.GetOk("allow_mv_without_rls"); ok {
+		withParams = append(withParams, fmt.Sprintf("allowMaterializedViewsWithoutRowLevelSecurity=%t", allowMVWithoutRLS.(bool)))
 	}
 	if updateExtentsCreationTime, ok := d.GetOk("update_extents_creation_time"); ok {
 		withParams = append(withParams, fmt.Sprintf("UpdateExtentsCreationTime=%t", updateExtentsCreationTime.(bool)))

--- a/adx/resource_adx_materialized_view_caching_policy_test.go
+++ b/adx/resource_adx_materialized_view_caching_policy_test.go
@@ -1,0 +1,107 @@
+package adx
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+type ADXMaterializedViewCachingPolicyTestResource struct{}
+
+func TestAccADXMaterializedViewCachingPolicy_basic(t *testing.T) {
+	var entity MaterializedViewCachingPolicy
+	r := ADXMaterializedViewCachingPolicyTestResource{}
+	rtcBuilder := BuildResourceTestContext[MaterializedViewCachingPolicy]()
+	rtc, _ := rtcBuilder.Test(t).Type("adx_materialized_view_caching_policy").
+		DatabaseName("test-db").
+		EntityType("caching").
+		ReadStatementFunc(GetAccTestPolicyReadStatementFunc()).Build()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: rtc.GetTestCheckEntityDestroyed(),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(rtc),
+				Check: resource.ComposeTestCheckFunc(
+					rtc.GetTestCheckEntityExists(&entity),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "view_name", rtc.EntityName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "data_hot_span", "3d"),
+				),
+			},
+		},
+	})
+}
+
+// Requires a follower database already configured with view `sample_shared_mv`
+func TestAccADXMaterializedViewCachingPolicy_follower(t *testing.T) {
+	var entity MaterializedViewCachingPolicy
+	r := ADXMaterializedViewCachingPolicyTestResource{}
+	rtcBuilder := BuildResourceTestContext[MaterializedViewCachingPolicy]()
+	rtc, _ := rtcBuilder.Test(t).Type("adx_materialized_view_caching_policy").
+		DatabaseName("shareable-db").
+		EntityType("caching").
+		EntityName("sample_shared_mv").
+		ReadStatementFunc(GetAccTestPolicyReadStatementFunc()).Build()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: r.follower(rtc, rtc.EntityName),
+				Check: resource.ComposeTestCheckFunc(
+					rtc.GetTestCheckEntityExists(&entity),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "view_name", rtc.EntityName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "data_hot_span", "3d"),
+				),
+			},
+		},
+	})
+}
+
+func (this ADXMaterializedViewCachingPolicyTestResource) basic(rtc *ResourceTestContext[MaterializedViewCachingPolicy]) string {
+	return fmt.Sprintf(`
+	%s
+
+	resource "%s" %s {
+		database_name = "%s"
+		view_name    = "${adx_materialized_view.test.name}"
+		data_hot_span = "3d"
+	}
+	`, this.template(rtc), rtc.Type, rtc.Label, rtc.DatabaseName)
+}
+
+func (this ADXMaterializedViewCachingPolicyTestResource) follower(rtc *ResourceTestContext[MaterializedViewCachingPolicy], viewName string) string {
+	return fmt.Sprintf(`
+
+	resource "%s" %s {
+		database_name     = "%s"
+		view_name         = "%s"
+		data_hot_span     = "3d"
+		follower_database = true
+	}
+	`, rtc.Type, rtc.Label, rtc.DatabaseName, viewName)
+}
+
+func (this ADXMaterializedViewCachingPolicyTestResource) template(rtc *ResourceTestContext[MaterializedViewCachingPolicy]) string {
+	return fmt.Sprintf(`
+	resource "adx_materialized_view" "test" {
+		database_name     = "%s"
+		name              = "%s"
+		query             = "${adx_table.test.name} | summarize arg_max(f3, *) by f1"
+		source_table_name = adx_table.test.name
+	}
+
+	resource "adx_table" "test" {
+		database_name = "%s"
+		name          = "table_for_mv_%s"
+		table_schema  = "f1:string,f2:string,f4:string,f3:int"
+	}
+	`, rtc.DatabaseName, rtc.EntityName, rtc.DatabaseName, acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+}

--- a/adx/resource_adx_materialized_view_test.go
+++ b/adx/resource_adx_materialized_view_test.go
@@ -1,0 +1,157 @@
+package adx
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+type ADXMaterializedViewTestResource struct{}
+
+func TestAccMaterializedView(t *testing.T) {
+	var entity ADXMaterializedView
+	tableName := "MvTest1"
+	r := ADXMaterializedViewTestResource{}
+	rtcBuilder := BuildResourceTestContext[ADXMaterializedView]()
+	rtc, _ := rtcBuilder.Test(t).Type("adx_materialized_view").
+		DatabaseName("test-db").
+		EntityType("materializedview").
+		ReadStatementFunc(func(id string) (string, error) {
+			viewId, err := parseADXMaterializedViewID(id)
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf(".show materialized-views | where Name == '%s' | extend Lookback=tostring(Lookback), IsHealthy=tolower(tostring(IsHealthy)), IsEnabled=tolower(tostring(IsEnabled)), AutoUpdateSchema=tolower(tostring(AutoUpdateSchema)), EffectiveDateTime", viewId.Name), nil
+		}).Build()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: rtc.GetTestCheckEntityDestroyed(),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basicMv(rtc, tableName),
+				Check: resource.ComposeTestCheckFunc(
+					rtc.GetTestCheckEntityExists(&entity),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "name", rtc.EntityName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "source_table_name", tableName),
+					rtc.CheckQueryResultSize(rtc.EntityName, 6, "Materialized view query check"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMaterializedView_RLSSourceTable(t *testing.T) {
+	var entity ADXMaterializedView
+	tableName := "MvTest1RLS"
+	r := ADXMaterializedViewTestResource{}
+	rtcBuilder := BuildResourceTestContext[ADXMaterializedView]()
+	rtc, _ := rtcBuilder.Test(t).Type("adx_materialized_view").
+		DatabaseName("test-db").
+		EntityType("materializedview").
+		ReadStatementFunc(func(id string) (string, error) {
+			viewId, err := parseADXMaterializedViewID(id)
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf(".show materialized-views | where Name == '%s' | extend Lookback=tostring(Lookback), IsHealthy=tolower(tostring(IsHealthy)), IsEnabled=tolower(tostring(IsEnabled)), AutoUpdateSchema=tolower(tostring(AutoUpdateSchema)), EffectiveDateTime", viewId.Name), nil
+		}).Build()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: rtc.GetTestCheckEntityDestroyed(),
+		Steps: []resource.TestStep{
+			{
+				Config: r.mvRLSTable(rtc, tableName),
+				Check: resource.ComposeTestCheckFunc(
+					rtc.GetTestCheckEntityExists(&entity),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "name", rtc.EntityName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "source_table_name", tableName),
+					rtc.CheckQueryResultSize(rtc.EntityName, 6, "Materialized view query check"),
+				),
+			},
+		},
+	})
+}
+
+func (this ADXMaterializedViewTestResource) basicMv(rtc *ResourceTestContext[ADXMaterializedView], tableName string) string {
+	return fmt.Sprintf(`
+	%s
+
+	resource "%s" "%s" {
+		name              = "%s"
+		database_name     = "%s"
+		source_table_name = adx_table.%s.name
+		backfill          = true
+		query             = "${adx_table.%s.name} | summarize arg_max(score,*) by team"
+	  }
+	`, this.basicTable(rtc, tableName), rtc.Type, rtc.Label, rtc.EntityName, rtc.DatabaseName, rtc.Label, rtc.Label)
+}
+
+func (this ADXMaterializedViewTestResource) mvRLSTable(rtc *ResourceTestContext[ADXMaterializedView], tableName string) string {
+	return fmt.Sprintf(`
+	%s
+
+	resource "%s" "%s" {
+		name              = "%s"
+		database_name     = "%s"
+		source_table_name = adx_table.%s.name
+		backfill          = true
+		query             = "${adx_table.%s.name} | summarize arg_max(score,*) by team"
+	  }
+	`, this.rlsTable(rtc, tableName), rtc.Type, rtc.Label, rtc.EntityName, rtc.DatabaseName, rtc.Label, rtc.Label)
+}
+
+func (this ADXMaterializedViewTestResource) basicTable(rtc *ResourceTestContext[ADXMaterializedView], tableName string) string {
+	return fmt.Sprintf(`
+	resource "adx_table" "%s" {
+		database_name    = "%s"
+		name             = "%s"
+		from_query {
+			query = <<EOT
+				let T = datatable(team:string, year: string, score:int)
+				[
+					"wildcats","1996",89,
+					"wildcats","1997",44,
+					"bears","1996",34,
+					"bears","1997",77,
+					"eagles","1996",65,
+					"eagles","1997",62,
+					"lizards","1996",96,
+					"lizards","1997",56,
+					"tigers","1997",20,
+					"tigers","1996",90,
+					"lions","1996",81,
+					"lions","1997",34
+				];
+				T
+			EOT
+			append = false
+		}
+	}
+	`, rtc.Label, rtc.DatabaseName, tableName)
+}
+
+func (this ADXMaterializedViewTestResource) rlsTable(rtc *ResourceTestContext[ADXMaterializedView], tableName string) string {
+	return fmt.Sprintf(`
+	%s
+
+	resource "adx_function" "%s" {
+		database_name = "%s"
+		name          = "test_rls_function_mv"
+		body          = "{${adx_table.%s.name} | where year == '1996'}"
+	}
+	  
+	resource "adx_table_row_level_security_policy" "%s" {
+		database_name = "%s"
+		table_name    = adx_table.%s.name
+		query         = adx_function.%s.name
+		enabled       = true
+	}
+	`, this.basicTable(rtc, tableName), rtc.Label, rtc.DatabaseName, rtc.Label, rtc.Label, rtc.DatabaseName, rtc.Label, rtc.Label)
+}

--- a/adx/resource_adx_materialized_view_test.go
+++ b/adx/resource_adx_materialized_view_test.go
@@ -98,11 +98,12 @@ func (this ADXMaterializedViewTestResource) mvRLSTable(rtc *ResourceTestContext[
 	%s
 
 	resource "%s" "%s" {
-		name              = "%s"
-		database_name     = "%s"
-		source_table_name = adx_table.%s.name
-		backfill          = true
-		query             = "${adx_table.%s.name} | summarize arg_max(score,*) by team"
+		name                 = "%s"
+		database_name        = "%s"
+		source_table_name    = adx_table.%s.name
+		backfill             = true
+		query                = "${adx_table.%s.name} | summarize arg_max(score,*) by team"
+		allow_mv_without_rls = true
 	  }
 	`, this.rlsTable(rtc, tableName), rtc.Type, rtc.Label, rtc.EntityName, rtc.DatabaseName, rtc.Label, rtc.Label)
 }
@@ -152,6 +153,8 @@ func (this ADXMaterializedViewTestResource) rlsTable(rtc *ResourceTestContext[AD
 		table_name    = adx_table.%s.name
 		query         = adx_function.%s.name
 		enabled       = true
+
+		allow_mv_without_rls = true
 	}
 	`, this.basicTable(rtc, tableName), rtc.Label, rtc.DatabaseName, rtc.Label, rtc.Label, rtc.DatabaseName, rtc.Label, rtc.Label)
 }

--- a/adx/utils.go
+++ b/adx/utils.go
@@ -252,3 +252,11 @@ func hasStatementResults(ctx context.Context, meta interface{}, clusterConfig *C
 	}
 	return hasResults, nil
 }
+
+func escapeEntityName(name string) string {
+	escapedName := name
+	if strings.Contains(name, "-") && !strings.HasPrefix(name, "[") {
+		escapedName = fmt.Sprintf("['%s']", name)
+	}
+	return escapedName
+}

--- a/adx/utils_policy.go
+++ b/adx/utils_policy.go
@@ -102,5 +102,12 @@ func deleteADXPolicy(ctx context.Context, d *schema.ResourceData, meta interface
 		return diag.Errorf("could not delete adx policy due to error parsing ID: %+v", err)
 	}
 
-	return deleteADXEntity(ctx, d, meta, clusterConfig, id.DatabaseName, fmt.Sprintf(".delete %s %s policy %s", entityType, id.Name, policyName))
+	followerDatabaseClause := ""
+	if followerDatabase, ok := d.GetOk("follower_database"); ok {
+		if followerDatabase.(bool) {
+			followerDatabaseClause = fmt.Sprintf("follower database %s", escapeEntityName(id.DatabaseName))
+		}
+	}
+
+	return deleteADXEntity(ctx, d, meta, clusterConfig, id.DatabaseName, fmt.Sprintf(".delete %s %s %s policy %s", followerDatabaseClause, entityType, id.Name, policyName))
 }

--- a/docs/resources/adx_materialized_view.md
+++ b/docs/resources/adx_materialized_view.md
@@ -19,6 +19,7 @@ resource "adx_materialized_view" "test" {
   database_name                = "test-db"
   source_table_name            = adx_table.test.name
   query                        = format("%s | extend hi=true | summarize count(), dcount(f1) by f2",adx_table.test.name)
+  allow_mv_without_rls         = true
 }
 ```
 
@@ -33,6 +34,7 @@ resource "adx_materialized_view" "test" {
 - **effective_date_time** (String, Optional) ISO8601 Date time string. If set, creation only backfills with records ingested after the datetime. `backfill` must also be set to true.
 - **auto_update_schema** (Boolean, Optional) Whether to auto-update the view on source table changes. Default is false. This option is valid only for views of type `arg_max(Timestamp,*)`, `arg_min(Timestamp, *)`, `take_any(*)` (only when columns argument is *). If this option is set to true, changes to source table will be automatically reflected in the materialized view.
 - **update_extents_creation_time** (Boolean, Optional) Relevant only when using `backfill`. If true, extent creation time is assigned based on datetime group-by key during the backfill process
+- **allow_mv_without_rls** (Boolean, Optional) Enables `allowMaterializedViewsWithoutRowLevelSecurity` flag during policy creation
 - **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
 
 `cluster` Configuration block for connection details about the target ADX cluster 

--- a/docs/resources/adx_materialized_view_caching_policy.md
+++ b/docs/resources/adx_materialized_view_caching_policy.md
@@ -41,6 +41,7 @@ resource "adx_materialized_view_caching_policy" "test" {
 - **view_name** (String, Required) Name of the materialized view containing the policy to modify
 - **database_name** (String, Required) Database name that the target materialized view is in
 - **data_hot_span** (String, Required) Timespan to store rows in SSD hot cache (Example: 30d for 30 days)
+- **follower_database** (Bool, Optional) True if the target materialized view is from an attached/follower database
 - **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
 
 `cluster` Configuration block for connection details about the target ADX cluster

--- a/docs/resources/adx_table.md
+++ b/docs/resources/adx_table.md
@@ -80,7 +80,7 @@ resource "adx_table" "test" {
 See [ADX - Ingest from Query](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/management/data-ingestion/ingest-from-query) for behavioral details of these parameters
 
 - **query** (String, Required) Result of this query will be used to build the target table
-- **append** (Boolean, Optional) If table already contains data, add to it instead of replacing. Default is false
+- **append** (Boolean, Required) If table already contains data, add to it instead of replacing.
 - **extend_schema** (Boolean, Optional) True if the command may extend the schema of the table. Default is "false". Only applied for updates
 - **recreate_schema** (Boolean, Optional) True if the command may recreate the schema of the table. Default is "false". Only applied for updates. Takes precedence over recreate_schema
 - **distributed** (Boolean, Optional) Indicates that the command ingests from all nodes executing the query in parallel. Default is "false"

--- a/docs/resources/adx_table_caching_policy.md
+++ b/docs/resources/adx_table_caching_policy.md
@@ -34,6 +34,7 @@ resource "adx_table_caching_policy" "test" {
 - **table_name** (String, Required) Name of the table containing the policy to modify
 - **database_name** (String, Required) Database name that the target table is in
 - **data_hot_span** (String, Required) Timespan to store rows in SSD hot cache (Example: 30d for 30 days)
+- **follower_database** (Bool, Optional) True if the target table is from an attached/follower database
 - **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
 
 `cluster` Configuration block for connection details about the target ADX cluster 

--- a/docs/resources/adx_table_row_level_security_policy.md
+++ b/docs/resources/adx_table_row_level_security_policy.md
@@ -42,6 +42,7 @@ resource "adx_table_row_level_security_policy" "test" {
 - **database_name** (String, Required) Database name that the target table is in
 - **query** (String, Required) The query to be run automatically when the target table is queried
 - **enabled** (Boolean, Optional) Enable or disable this policy
+- **allow_mv_without_rls** (Boolean, Optional) Enables the allowMaterializedViewsWithoutRowLevelSecurity flag during policy creation
 - **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
 
 `cluster` Configuration block for connection details about the target ADX cluster


### PR DESCRIPTION
# Caching polices for tables and views in [follower databases](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/cluster-follower)

* Added acceptance tests for caching policies on materialized views
* follower_database flag for both table and mv caching policies
* Updated documentation 

> NOTE: Running acceptance tests now requires two clusters/databases with follower database preconfigured. We will need to include the azurerm tf examples soon for creating the full test environment for acceptance testing.

```
$ TF_ACC=1 go test -v ./adx
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccADXFunction_basic
--- PASS: TestAccADXFunction_basic (3.10s)
=== RUN   TestAccADXMaterializedViewCachingPolicy_basic
--- PASS: TestAccADXMaterializedViewCachingPolicy_basic (2.86s)
=== RUN   TestAccADXMaterializedViewCachingPolicy_follower
--- PASS: TestAccADXMaterializedViewCachingPolicy_follower (1.68s)
=== RUN   TestAccMaterializedView
--- PASS: TestAccMaterializedView (3.30s)
=== RUN   TestAccMaterializedView_RLSSourceTable
--- PASS: TestAccMaterializedView_RLSSourceTable (4.29s)
=== RUN   TestAccADXTableCachingPolicy_basic
--- PASS: TestAccADXTableCachingPolicy_basic (2.17s)
=== RUN   TestAccADXTableCachingPolicy_follower
--- PASS: TestAccADXTableCachingPolicy_follower (1.72s)
=== RUN   TestAccADXTableIngestionBatchingPolicy_basic
--- PASS: TestAccADXTableIngestionBatchingPolicy_basic (2.15s)
=== RUN   TestAccTableMapping_basicJson
--- PASS: TestAccTableMapping_basicJson (2.12s)
=== RUN   TestAccTableMapping_basicCsv
--- PASS: TestAccTableMapping_basicCsv (2.13s)
=== RUN   TestAccADXTablePartitioningPolicy_basic
--- PASS: TestAccADXTablePartitioningPolicy_basic (5.49s)
PASS
ok  	github.com/favoretti/terraform-provider-adx/adx	31.457s
```