### PR TITLE
Add docstring and folder params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.18
+
+* Added folder and docstring parameters to functions, materialized views, and tables
+
 ## v0.0.17
 
 * Bug fixes for tables and views "with" attributes when resource is updated (some are incompatible with .alter)

--- a/adx/resource_adx_materialized_view.go
+++ b/adx/resource_adx_materialized_view.go
@@ -22,6 +22,8 @@ type ADXMaterializedView struct {
 	AutoUpdateSchema  string
 	EffectiveDateTime value.DateTime
 	Lookback          string
+	Folder            string
+	DocString         string
 }
 
 func resourceADXMaterializedView() *schema.Resource {
@@ -31,7 +33,7 @@ func resourceADXMaterializedView() *schema.Resource {
 		ReadContext:   resourceADXMaterializedViewRead,
 		DeleteContext: resourceADXMaterializedViewDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -104,6 +106,16 @@ func resourceADXMaterializedView() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+
+			"folder": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"docstring": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 		CustomizeDiff: clusterConfigCustomDiff,
 	}
@@ -146,6 +158,12 @@ func resourceADXMaterializedViewCreateUpdate(ctx context.Context, d *schema.Reso
 	}
 	if effectiveDateTime, ok := d.GetOk("effective_date_time"); ok && new {
 		withParams = append(withParams, fmt.Sprintf("effectiveDateTime=%s", effectiveDateTime.(string)))
+	}
+	if docstring, ok := d.GetOk("docstring"); ok && new {
+		withParams = append(withParams, fmt.Sprintf("docstring='%s'", docstring))
+	}
+	if folder, ok := d.GetOk("folder"); ok && new {
+		withParams = append(withParams, fmt.Sprintf("folder='%s'", folder))
 	}
 
 	withClause := ""
@@ -201,6 +219,8 @@ func resourceADXMaterializedViewRead(ctx context.Context, d *schema.ResourceData
 		d.Set("query", resultSet[0].Query)
 		d.Set("auto_update_schema", autoUpdateSchema)
 		d.Set("effective_date_time", resultSet[0].EffectiveDateTime.String())
+		d.Set("docstring", resultSet[0].DocString)
+		d.Set("folder", resultSet[0].Folder)
 	}
 
 	return diags

--- a/adx/resource_adx_materialized_view_test.go
+++ b/adx/resource_adx_materialized_view_test.go
@@ -37,6 +37,8 @@ func TestAccMaterializedView(t *testing.T) {
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "name", rtc.EntityName),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "source_table_name", tableName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "folder", ""),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "docstring", ""),
 					rtc.CheckQueryResultSize(rtc.EntityName, 6, "Materialized view query check"),
 				),
 			},
@@ -88,6 +90,8 @@ func TestAccMaterializedView_RLSSourceTable(t *testing.T) {
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "name", rtc.EntityName),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "source_table_name", tableName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "folder", "iamafolder"),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "docstring", "alwaysuptodate"),
 					rtc.CheckQueryResultSize(rtc.EntityName, 6, "Materialized view query check"),
 				),
 			},
@@ -98,6 +102,8 @@ func TestAccMaterializedView_RLSSourceTable(t *testing.T) {
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "name", rtc.EntityName),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "source_table_name", tableName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "folder", "iamafolder"),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "docstring", "alwaysuptodate"),
 					rtc.CheckQueryResultSize(rtc.EntityName, 6, "Materialized view query check"),
 				),
 			},
@@ -136,6 +142,8 @@ func (this ADXMaterializedViewTestResource) mvRLSTable(rtc *ResourceTestContext[
 		backfill             = true
 		query                = "${adx_table.%s.name} %s | summarize arg_max(score,*) by team"
 		allow_mv_without_rls = true
+		folder     			 = "iamafolder"
+		docstring     	     = "alwaysuptodate"
 	  }
 	`, this.rlsTable(rtc, tableName), rtc.Type, rtc.Label, rtc.EntityName, rtc.DatabaseName, rtc.Label, rtc.Label, extraClause)
 }

--- a/adx/resource_adx_table_test.go
+++ b/adx/resource_adx_table_test.go
@@ -7,21 +7,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-type ADXFunctionTestResource struct{}
+type ADXTableTestResource struct{}
 
-func TestAccADXFunction_basic(t *testing.T) {
-	var entity ADXFunction
-	r := ADXFunctionTestResource{}
-	rtcBuilder := BuildResourceTestContext[ADXFunction]()
-	rtc, _ := rtcBuilder.Test(t).Type("adx_function").
+func TestAccADXTable_basic(t *testing.T) {
+	var entity TableSchema
+	r := ADXTableTestResource{}
+	rtcBuilder := BuildResourceTestContext[TableSchema]()
+	rtc, _ := rtcBuilder.Test(t).Type("adx_table").
 		DatabaseName("test-db").
-		EntityType("function").
+		EntityType("table").
 		ReadStatementFunc(func(id string) (string, error) {
-			funcId, err := parseADXFunctionID(id)
+			funcId, err := parseADXTableID(id)
 			if err != nil {
 				return "", err
 			}
-			return fmt.Sprintf(".show functions | where Name == '%s'", funcId.Name), nil
+			return fmt.Sprintf(".show tables | where TableName == '%s'", funcId.Name), nil
 		}).Build()
 
 	resource.Test(t, resource.TestCase{
@@ -35,8 +35,7 @@ func TestAccADXFunction_basic(t *testing.T) {
 					rtc.GetTestCheckEntityExists(&entity),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "name", rtc.EntityName),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
-					resource.TestCheckResourceAttr(rtc.GetTFName(), "parameters", "()"),
-					resource.TestCheckResourceAttr(rtc.GetTFName(), "body", "{Test1 \n| limit 10}"),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "table_schema", "f1:string,f2:string,f4:string,f3:int"),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "docstring", "This is table"),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "folder", "iamafolder"),
 				),
@@ -45,28 +44,15 @@ func TestAccADXFunction_basic(t *testing.T) {
 	})
 }
 
-func (this ADXFunctionTestResource) basic(rtc *ResourceTestContext[ADXFunction]) string {
+func (this ADXTableTestResource) basic(rtc *ResourceTestContext[TableSchema]) string {
 	return fmt.Sprintf(`
-	%s
 
 	resource "%s" %s {
 		database_name = "%s"
 		name          = "%s"
-		body          = "{${adx_table.test.name} \n| limit 10}"
-		docstring     = "This is table"
-		folder        = "iamafolder"
-	}
-	`, this.template(rtc), rtc.Type, rtc.Label, rtc.DatabaseName, rtc.EntityName)
-}
-
-func (this ADXFunctionTestResource) template(rtc *ResourceTestContext[ADXFunction]) string {
-	return fmt.Sprintf(`
-	resource "adx_table" "test" {
-		database_name = "%s"
-		name          = "Test1"
 		table_schema  = "f1:string,f2:string,f4:string,f3:int"
 		docstring     = "This is table"
 		folder        = "iamafolder"
 	}
-	`, rtc.DatabaseName)
+	`, rtc.Type, rtc.Label, rtc.DatabaseName, rtc.EntityName)
 }

--- a/docs/resources/adx_function.md
+++ b/docs/resources/adx_function.md
@@ -28,6 +28,8 @@ resource "adx_function" "test" {
 - **database_name** (String, Required) Database name in which this function should be created.
 - **body** (String, Required) Function body enclosed in curly braces {}
 - **parameters** (String, Optional) Function parameters enclosed in parenthesis (myLimit:long)
+- **folder** (String, Optional) Name of the folder in which to place this entity
+- **docstring** (String, Optional) Free text describing the entity to be added. This string is presented in various UX settings next to the entity names.
 - **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
 
 `cluster` Configuration block for connection details about the target ADX cluster

--- a/docs/resources/adx_materialized_view.md
+++ b/docs/resources/adx_materialized_view.md
@@ -35,6 +35,8 @@ resource "adx_materialized_view" "test" {
 - **auto_update_schema** (Boolean, Optional) Whether to auto-update the view on source table changes. Default is false. This option is valid only for views of type `arg_max(Timestamp,*)`, `arg_min(Timestamp, *)`, `take_any(*)` (only when columns argument is *). If this option is set to true, changes to source table will be automatically reflected in the materialized view.
 - **update_extents_creation_time** (Boolean, Optional) Relevant only when using `backfill`. If true, extent creation time is assigned based on datetime group-by key during the backfill process
 - **allow_mv_without_rls** (Boolean, Optional) Enables `allowMaterializedViewsWithoutRowLevelSecurity` flag during policy creation
+- **folder** (String, Optional) Name of the folder in which to place this entity
+- **docstring** (String, Optional) Free text describing the entity to be added. This string is presented in various UX settings next to the entity names.
 - **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
 
 `cluster` Configuration block for connection details about the target ADX cluster 

--- a/docs/resources/adx_table.md
+++ b/docs/resources/adx_table.md
@@ -68,6 +68,8 @@ resource "adx_table" "test" {
 - **column** (String, Optional) One or more `column` blocks defined below.
 - **from_query** (String, Optional) One `from_query` blocks defined below.
 - **merge_on_update** (Boolean, Optional) If true, prevent removal of columns or configuration during schema changes. Changes become additive only. See Azure docs on difference between `.alter` and `.alter-merge`. Default is false
+- **folder** (String, Optional) Name of the folder in which to place this entity
+- **docstring** (String, Optional) Free text describing the entity to be added. This string is presented in various UX settings next to the entity names.
 - **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
 
 `column` Configures a column and supports the following:


### PR DESCRIPTION
* Added `docstring` and `folder` parameters to to functions, tables and views.
* Added simple acceptance test for adx_table

Resolves #27

```
$ TF_ACC=1 go test -v ./adx
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccADXFunction_basic
--- PASS: TestAccADXFunction_basic (2.56s)
=== RUN   TestAccADXMaterializedViewCachingPolicy_basic
--- PASS: TestAccADXMaterializedViewCachingPolicy_basic (6.47s)
=== RUN   TestAccADXMaterializedViewCachingPolicy_follower
--- PASS: TestAccADXMaterializedViewCachingPolicy_follower (26.42s)
=== RUN   TestAccMaterializedView
--- PASS: TestAccMaterializedView (5.94s)
=== RUN   TestAccMaterializedView_RLSSourceTable
--- PASS: TestAccMaterializedView_RLSSourceTable (6.85s)
=== RUN   TestAccADXTableCachingPolicy_basic
--- PASS: TestAccADXTableCachingPolicy_basic (5.41s)
=== RUN   TestAccADXTableCachingPolicy_follower
--- PASS: TestAccADXTableCachingPolicy_follower (26.55s)
=== RUN   TestAccADXTableIngestionBatchingPolicy_basic
--- PASS: TestAccADXTableIngestionBatchingPolicy_basic (4.29s)
=== RUN   TestAccTableMapping_basicJson
--- PASS: TestAccTableMapping_basicJson (2.65s)
=== RUN   TestAccTableMapping_basicCsv
--- PASS: TestAccTableMapping_basicCsv (2.76s)
=== RUN   TestAccADXTablePartitioningPolicy_basic
--- PASS: TestAccADXTablePartitioningPolicy_basic (6.04s)
=== RUN   TestAccADXTable_basic
--- PASS: TestAccADXTable_basic (1.75s)
PASS
ok  	github.com/favoretti/terraform-provider-adx/adx	97.924s
```
