### PR TITLE
added streaming ingestion policy for tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.0.18
 
 * Added folder and docstring parameters to functions, materialized views, and tables
+* Adding streamingingestion policy resource for tables
 
 ## v0.0.17
 

--- a/adx/provider.go
+++ b/adx/provider.go
@@ -61,6 +61,7 @@ func Provider() *schema.Provider {
 			"adx_table_partitioning_policy":                   resourceADXTablePartitioningPolicy(),
 			"adx_table_caching_policy":                        resourceADXTableCachingPolicy(),
 			"adx_table_update_policy":                         resourceADXTableUpdatePolicy(),
+			"adx_table_streaming_ingestion_policy":            resourceADXTableStreamingIngestionPolicy(),
 			"adx_function":                                    resourceADXFunction(),
 			"adx_materialized_view":                           resourceADXMaterializedView(),
 			"adx_materialized_view_caching_policy":            resourceADXMaterializedViewCachingPolicy(),

--- a/adx/resource_adx_table_streaming_ingestion_policy.go
+++ b/adx/resource_adx_table_streaming_ingestion_policy.go
@@ -14,7 +14,7 @@ import (
 
 type TableStreamingIngestionPolicy struct {
 	IsEnabled         bool
-	HintAllocatedRate float64
+	HintAllocatedRate string
 }
 
 func resourceADXTableStreamingIngestionPolicy() *schema.Resource {
@@ -93,10 +93,15 @@ func resourceADXTableStreamingIngestionPolicyRead(ctx context.Context, d *schema
 			return diag.Errorf("error parsing policy streamingingestion for Table %q (Database %q): %+v", id.Name, id.DatabaseName, err)
 		}
 
+		rate, rateErr := strconv.ParseFloat(policy.HintAllocatedRate, 64)
+		if rateErr != nil {
+			return diag.Errorf("error parsing hint_allocated_rate from ADX API for policy streamingingestion for Table %q (Database %q): %+v", id.Name, id.DatabaseName, rateErr)
+		}
+
 		d.Set("table_name", id.Name)
 		d.Set("database_name", id.DatabaseName)
 		d.Set("enabled", policy.IsEnabled)
-		d.Set("hint_allocated_rate", policy.HintAllocatedRate)
+		d.Set("hint_allocated_rate", rate)
 	}
 
 	return diags

--- a/adx/resource_adx_table_streaming_ingestion_policy.go
+++ b/adx/resource_adx_table_streaming_ingestion_policy.go
@@ -1,0 +1,107 @@
+package adx
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"encoding/json"
+
+	"github.com/favoretti/terraform-provider-adx/adx/validate"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type TableStreamingIngestionPolicy struct {
+	IsEnabled         bool
+	HintAllocatedRate float64
+}
+
+func resourceADXTableStreamingIngestionPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceADXTableStreamingIngestionPolicyCreateUpdate,
+		ReadContext:   resourceADXTableStreamingIngestionPolicyRead,
+		DeleteContext: resourceADXTableStreamingIngestionPolicyDelete,
+		UpdateContext: resourceADXTableStreamingIngestionPolicyCreateUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cluster": getClusterConfigInputSchema(),
+			"database_name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+
+			"table_name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+
+			"enabled": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+
+			"hint_allocated_rate": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+			},
+		},
+		CustomizeDiff: clusterConfigCustomDiff,
+	}
+}
+
+func resourceADXTableStreamingIngestionPolicyCreateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	tableName := d.Get("table_name").(string)
+	databaseName := d.Get("database_name").(string)
+	enabled := d.Get("enabled").(bool)
+
+	hintAllocatedRateString := "null"
+	if hintAllocatedRate, ok := d.GetOk("hint_allocated_rate"); ok {
+		hintAllocatedRateString = strconv.FormatFloat(hintAllocatedRate.(float64), 'f', -1, 64)
+	}
+
+	enabledString := strconv.FormatBool(enabled)
+
+	createStatement := fmt.Sprintf(".alter table %s policy streamingingestion '{\"IsEnabled\": %s, \"HintAllocatedRate\": %s}'", tableName, enabledString, hintAllocatedRateString)
+
+	if err := createADXPolicy(ctx, d, meta, "table", "streamingingestion", databaseName, tableName, createStatement); err != nil {
+		return diag.Errorf("%+v", err)
+	}
+
+	return resourceADXTableStreamingIngestionPolicyRead(ctx, d, meta)
+}
+
+func resourceADXTableStreamingIngestionPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	id, resultSet, diags := readADXPolicy(ctx, d, meta, "table", "streamingingestion")
+	if diags.HasError() || resultSet == nil || len(resultSet) == 0 {
+		return diags
+	}
+
+	if resultSet[0].Policy == "null" {
+		d.SetId("")
+	} else {
+
+		var policy TableStreamingIngestionPolicy
+		if err := json.Unmarshal([]byte(resultSet[0].Policy), &policy); err != nil {
+			return diag.Errorf("error parsing policy streamingingestion for Table %q (Database %q): %+v", id.Name, id.DatabaseName, err)
+		}
+
+		d.Set("table_name", id.Name)
+		d.Set("database_name", id.DatabaseName)
+		d.Set("enabled", policy.IsEnabled)
+		d.Set("hint_allocated_rate", policy.HintAllocatedRate)
+	}
+
+	return diags
+}
+
+func resourceADXTableStreamingIngestionPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return deleteADXPolicy(ctx, d, meta, "table", "streamingingestion")
+}

--- a/adx/resource_adx_table_streaming_ingestion_policy_test.go
+++ b/adx/resource_adx_table_streaming_ingestion_policy_test.go
@@ -1,0 +1,66 @@
+package adx
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+type ADXTableStreamingIngestionPolicyTestResource struct{}
+
+func TestAccADXTableStreamingIngestionPolicy_basic(t *testing.T) {
+	var entity TableStreamingIngestionPolicy
+	r := ADXTableStreamingIngestionPolicyTestResource{}
+	rtcBuilder := BuildResourceTestContext[TableStreamingIngestionPolicy]()
+	rtc, _ := rtcBuilder.Test(t).Type("adx_table_streaming_ingestion_policy").
+		DatabaseName("test-db").
+		EntityType("streamingingestion").
+		ReadStatementFunc(GetAccTestPolicyReadStatementFunc()).Build()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: rtc.GetTestCheckEntityDestroyed(),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(rtc),
+				Check: resource.ComposeTestCheckFunc(
+					rtc.GetTestCheckEntityExists(&entity),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "table_name", rtc.EntityName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "enabled", "true"),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "hint_allocated_rate", "2.1"),
+				),
+			},
+			{
+				ResourceName:      rtc.GetTFName(),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func (this ADXTableStreamingIngestionPolicyTestResource) basic(rtc *ResourceTestContext[TableStreamingIngestionPolicy]) string {
+	return fmt.Sprintf(`
+	%s
+
+	resource "%s" %s {
+		database_name         = "%s"
+		table_name            = "${adx_table.test.name}"
+		enabled 		      = true
+		hint_allocated_rate   = 2.1
+	}
+	`, this.template(rtc), rtc.Type, rtc.Label, rtc.DatabaseName)
+}
+
+func (this ADXTableStreamingIngestionPolicyTestResource) template(rtc *ResourceTestContext[TableStreamingIngestionPolicy]) string {
+	return fmt.Sprintf(`
+	resource "adx_table" "test" {
+		database_name = "%s"
+		name          = "%s"
+		table_schema  = "f1:string,f2:string,f4:string,f3:int"
+	}
+	`, rtc.DatabaseName, rtc.EntityName)
+}

--- a/docs/resources/adx_table_streaming_ingestion_policy.md
+++ b/docs/resources/adx_table_streaming_ingestion_policy.md
@@ -35,7 +35,7 @@ resource "adx_table_streaming_ingestion_policy" "test" {
 - **table_name** (String, Required) Name of the table containing the policy to modify
 - **database_name** (String, Required) Database name that the target table is in
 - **enabled** (Boolean, Required) Defines the status of streaming ingestion functionality for the table. Must explicitly be set to true or false.
-- **hint_allocated_rate** If set provides a hint on the hourly volume of data in gigabytes expected for the table. This hint helps the system adjust the amount of resources that are allocated for a table in support of streaming ingestion. default value null (unset)
+- **hint_allocated_rate** (Decimal, Optional) If set provides a hint on the hourly volume of data in gigabytes expected for the table. This hint helps the system adjust the amount of resources that are allocated for a table in support of streaming ingestion. default value null (unset)
 - **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
 
 `cluster` Configuration block for connection details about the target ADX cluster

--- a/docs/resources/adx_table_streamingingestion_policy.md
+++ b/docs/resources/adx_table_streamingingestion_policy.md
@@ -1,0 +1,54 @@
+---
+page_title: "adx_table_streaming_ingestion_policy Resource - terraform-provider-adx"
+subcategory: ""
+description: |-
+  Manages the streaming ingestion policy of a table in ADX.
+---
+
+# Resource `adx_table_streaming_ingestion_policy`
+
+Manages streaming ingestion policy for a table in ADX.
+
+See: [ADX - Streaming Ingestion Policy](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/streamingingestionpolicy)
+
+## Example Usage
+
+```terraform
+
+resource "adx_table" "test" {
+  name          = "Test1"
+  database_name = "test-db"
+  table_schema  = "f1:string,f2:string,f3:int"
+}
+
+resource "adx_table_streaming_ingestion_policy" "test" {
+  database_name         = "test-db"
+  table_name            = adx_table.test.name
+  enabled               = true
+  hint_allocated_rate   = 2.1
+}
+
+```
+
+## Argument Reference
+
+- **table_name** (String, Required) Name of the table containing the policy to modify
+- **database_name** (String, Required) Database name that the target table is in
+- **enabled** (Boolean, Required) Defines the status of streaming ingestion functionality for the table. Must explicitly be set to true or false.
+- **hint_allocated_rate** If set provides a hint on the hourly volume of data in gigabytes expected for the table. This hint helps the system adjust the amount of resources that are allocated for a table in support of streaming ingestion. default value null (unset)
+- **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
+
+`cluster` Configuration block for connection details about the target ADX cluster
+
+*Note*: Any attributes specified here override the cluster config specified in the provider. Once a resource overrides an attribute specified in the provider, it will be stored explicitly as state for that resource and will not be possible to go back to the provider config unless explicitly unset.
+
+- **uri** - (String, Optional) Target ADX cluster endpoint URI, starting with `https://`
+- **client_id** - (String, Optional) The client ID for a service principal having admin access to this cluster/database. 
+- **client_secret** - (String, Optional) The client secret for a service principal having admin access to this cluster/database
+- **tenant_id** - (String, Optional) Id for the tenant to which the service principal belongs
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- **id** - The ID of this resource.


### PR DESCRIPTION
* New resource `adx_table_streaming_ingestion_policy`

Resolves #26

```
$ TF_ACC=1 go test -v ./adx
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccADXFunction_basic
--- PASS: TestAccADXFunction_basic (2.27s)
=== RUN   TestAccADXMaterializedViewCachingPolicy_basic
--- PASS: TestAccADXMaterializedViewCachingPolicy_basic (6.23s)
=== RUN   TestAccADXMaterializedViewCachingPolicy_follower
--- PASS: TestAccADXMaterializedViewCachingPolicy_follower (37.43s)
=== RUN   TestAccMaterializedView
--- PASS: TestAccMaterializedView (5.31s)
=== RUN   TestAccMaterializedView_RLSSourceTable
--- PASS: TestAccMaterializedView_RLSSourceTable (6.79s)
=== RUN   TestAccADXTableCachingPolicy_basic
--- PASS: TestAccADXTableCachingPolicy_basic (4.72s)
=== RUN   TestAccADXTableCachingPolicy_follower
--- PASS: TestAccADXTableCachingPolicy_follower (21.38s)
=== RUN   TestAccADXTableIngestionBatchingPolicy_basic
--- PASS: TestAccADXTableIngestionBatchingPolicy_basic (4.21s)
=== RUN   TestAccTableMapping_basicJson
--- PASS: TestAccTableMapping_basicJson (2.53s)
=== RUN   TestAccTableMapping_basicCsv
--- PASS: TestAccTableMapping_basicCsv (3.39s)
=== RUN   TestAccADXTablePartitioningPolicy_basic
--- PASS: TestAccADXTablePartitioningPolicy_basic (7.67s)
=== RUN   TestAccADXTableStreamingIngestionPolicy_basic
--- PASS: TestAccADXTableStreamingIngestionPolicy_basic (2.65s)
=== RUN   TestAccADXTable_basic
--- PASS: TestAccADXTable_basic (1.67s)
PASS
ok  	github.com/favoretti/terraform-provider-adx/adx	106.478s
```