### PR TITLE
fixed issue #35 async materialized view creation w/operation polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.20
+
+* Fixed issue #35. Async materialized view creation now properly polls ADX operations to wait for completion
+
 ## v0.0.19
 
 * Fixed issue #30. Float parsing issues for default and empty values from ADX for streamingingestion policy

--- a/adx/resource_adx_function.go
+++ b/adx/resource_adx_function.go
@@ -99,10 +99,10 @@ func resourceADXFunctionCreateUpdate(ctx context.Context, d *schema.ResourceData
 
 	var withParams []string
 
-	if docstring, ok := d.GetOk("docstring"); ok && new {
+	if docstring, ok := d.GetOk("docstring"); ok {
 		withParams = append(withParams, fmt.Sprintf("docstring='%s'", docstring))
 	}
-	if folder, ok := d.GetOk("folder"); ok && new {
+	if folder, ok := d.GetOk("folder"); ok {
 		withParams = append(withParams, fmt.Sprintf("folder='%s'", folder))
 	}
 

--- a/adx/resource_adx_function_test.go
+++ b/adx/resource_adx_function_test.go
@@ -37,6 +37,16 @@ func TestAccADXFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "parameters", "()"),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "body", "{Test1 \n| limit 10}"),
+				),
+			},
+			{
+				Config: r.basic_update(rtc),
+				Check: resource.ComposeTestCheckFunc(
+					rtc.GetTestCheckEntityExists(&entity),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "name", rtc.EntityName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "parameters", "()"),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "body", "{Test1 \n| limit 100}"),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "docstring", "This is table"),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "folder", "iamafolder"),
 				),
@@ -53,6 +63,18 @@ func (this ADXFunctionTestResource) basic(rtc *ResourceTestContext[ADXFunction])
 		database_name = "%s"
 		name          = "%s"
 		body          = "{${adx_table.test.name} \n| limit 10}"
+	}
+	`, this.template(rtc), rtc.Type, rtc.Label, rtc.DatabaseName, rtc.EntityName)
+}
+
+func (this ADXFunctionTestResource) basic_update(rtc *ResourceTestContext[ADXFunction]) string {
+	return fmt.Sprintf(`
+	%s
+
+	resource "%s" %s {
+		database_name = "%s"
+		name          = "%s"
+		body          = "{${adx_table.test.name} \n| limit 100}"
 		docstring     = "This is table"
 		folder        = "iamafolder"
 	}

--- a/adx/resource_adx_table_test.go
+++ b/adx/resource_adx_table_test.go
@@ -36,6 +36,15 @@ func TestAccADXTable_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "name", rtc.EntityName),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "table_schema", "f1:string,f2:string,f4:string,f3:int"),
+				),
+			},
+			{
+				Config: r.basic_update(rtc),
+				Check: resource.ComposeTestCheckFunc(
+					rtc.GetTestCheckEntityExists(&entity),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "name", rtc.EntityName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "table_schema", "f1:string,f2:string,f4:string,f3:int"),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "docstring", "This is table"),
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "folder", "iamafolder"),
 				),
@@ -45,6 +54,17 @@ func TestAccADXTable_basic(t *testing.T) {
 }
 
 func (this ADXTableTestResource) basic(rtc *ResourceTestContext[TableSchema]) string {
+	return fmt.Sprintf(`
+
+	resource "%s" %s {
+		database_name = "%s"
+		name          = "%s"
+		table_schema  = "f1:string,f2:string,f4:string,f3:int"
+	}
+	`, rtc.Type, rtc.Label, rtc.DatabaseName, rtc.EntityName)
+}
+
+func (this ADXTableTestResource) basic_update(rtc *ResourceTestContext[TableSchema]) string {
 	return fmt.Sprintf(`
 
 	resource "%s" %s {


### PR DESCRIPTION
* Fixed issue #35. Async materialized view creation now properly polls ADX operations to wait for completion
* Fixed bug with changing an existing resources folder or doc string
* Updated a few tests cases (function and table) to better check for updates (to things like folder attribute)