### PR TITLE
Add concurrency and maxSourceRecordsForSingleIngest as optional params to MVs

### DIFF
--- a/adx/resource_adx_materialized_view.go
+++ b/adx/resource_adx_materialized_view.go
@@ -117,6 +117,16 @@ func resourceADXMaterializedView() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
+			"max_source_records_for_single_ingest": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+
+			"concurrency": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 		},
 		CustomizeDiff: clusterConfigCustomDiff,
 		Timeouts: &schema.ResourceTimeout{
@@ -163,6 +173,12 @@ func resourceADXMaterializedViewCreateUpdate(ctx context.Context, d *schema.Reso
 	}
 	if folder, ok := d.GetOk("folder"); ok {
 		withParams = append(withParams, fmt.Sprintf("folder='%s'", folder))
+	}
+	if maxSourceRecordsForSingleIngest, ok := d.GetOk("max_source_records_for_single_ingest"); ok {
+		withParams = append(withParams, fmt.Sprintf("MaxSourceRecordsForSingleIngest=%d", maxSourceRecordsForSingleIngest))
+	}
+	if concurrency, ok := d.GetOk("concurrency"); ok {
+		withParams = append(withParams, fmt.Sprintf("Concurrency=%d", concurrency))
 	}
 
 	withClause := ""

--- a/adx/resource_adx_materialized_view.go
+++ b/adx/resource_adx_materialized_view.go
@@ -174,10 +174,10 @@ func resourceADXMaterializedViewCreateUpdate(ctx context.Context, d *schema.Reso
 	if folder, ok := d.GetOk("folder"); ok {
 		withParams = append(withParams, fmt.Sprintf("folder='%s'", folder))
 	}
-	if maxSourceRecordsForSingleIngest, ok := d.GetOk("max_source_records_for_single_ingest"); ok {
+	if maxSourceRecordsForSingleIngest, ok := d.GetOk("max_source_records_for_single_ingest"); ok && new {
 		withParams = append(withParams, fmt.Sprintf("MaxSourceRecordsForSingleIngest=%d", maxSourceRecordsForSingleIngest))
 	}
-	if concurrency, ok := d.GetOk("concurrency"); ok {
+	if concurrency, ok := d.GetOk("concurrency"); ok && new {
 		withParams = append(withParams, fmt.Sprintf("Concurrency=%d", concurrency))
 	}
 

--- a/adx/resource_adx_materialized_view_test.go
+++ b/adx/resource_adx_materialized_view_test.go
@@ -56,7 +56,7 @@ func TestAccMaterializedView(t *testing.T) {
 				ResourceName:            rtc.GetTFName(),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_mv_without_rls", "async", "backfill", "update_extents_creation_time"},
+				ImportStateVerifyIgnore: []string{"allow_mv_without_rls", "async", "backfill", "update_extents_creation_time", "max_source_records_for_single_ingest", "concurrency"},
 			},
 		},
 	})
@@ -111,7 +111,7 @@ func TestAccMaterializedView_RLSSourceTable(t *testing.T) {
 				ResourceName:            rtc.GetTFName(),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_mv_without_rls", "async", "backfill", "update_extents_creation_time"},
+				ImportStateVerifyIgnore: []string{"allow_mv_without_rls", "async", "backfill", "update_extents_creation_time", "max_source_records_for_single_ingest", "concurrency"},
 			},
 		},
 	})
@@ -162,7 +162,7 @@ func TestAccMaterializedView_BackfillAsync(t *testing.T) {
 				ResourceName:            rtc.GetTFName(),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_mv_without_rls", "async", "backfill", "update_extents_creation_time"},
+				ImportStateVerifyIgnore: []string{"allow_mv_without_rls", "async", "backfill", "update_extents_creation_time", "max_source_records_for_single_ingest", "concurrency"},
 			},
 		},
 	})
@@ -173,11 +173,13 @@ func (this ADXMaterializedViewTestResource) basicMv(rtc *ResourceTestContext[ADX
 	%s
 
 	resource "%s" "%s" {
-		name              = "%s"
-		database_name     = "%s"
-		source_table_name = adx_table.%s.name
-		backfill          = true
-		query             = "${adx_table.%s.name} %s | summarize arg_max(score,*) by team"
+		name              						= "%s"
+		database_name     						= "%s"
+		source_table_name 						= adx_table.%s.name
+		backfill          						= true
+		query             						= "${adx_table.%s.name} %s | summarize arg_max(score,*) by team"
+		max_source_records_for_single_ingest 	= 3000000
+		concurrency								= 2
 	  }
 	`, this.basicTable(rtc, tableName), rtc.Type, rtc.Label, rtc.EntityName, rtc.DatabaseName, rtc.Label, rtc.Label, extraClause)
 }
@@ -187,14 +189,16 @@ func (this ADXMaterializedViewTestResource) mvRLSTable(rtc *ResourceTestContext[
 	%s
 
 	resource "%s" "%s" {
-		name                 = "%s"
-		database_name        = "%s"
-		source_table_name    = adx_table.%s.name
-		backfill             = true
-		query                = "${adx_table.%s.name} %s | summarize arg_max(score,*) by team"
-		allow_mv_without_rls = true
-		folder     			 = "iamafolder"
-		docstring     	     = "alwaysuptodate"
+		name                 					= "%s"
+		database_name        					= "%s"
+		source_table_name    					= adx_table.%s.name
+		backfill             					= true
+		query                					= "${adx_table.%s.name} %s | summarize arg_max(score,*) by team"
+		allow_mv_without_rls 					= true
+		folder     			 					= "iamafolder"
+		docstring     	     					= "alwaysuptodate"
+		max_source_records_for_single_ingest 	= 3000000
+		concurrency								= 2
 	  }
 	`, this.rlsTable(rtc, tableName), rtc.Type, rtc.Label, rtc.EntityName, rtc.DatabaseName, rtc.Label, rtc.Label, extraClause)
 }
@@ -204,12 +208,14 @@ func (this ADXMaterializedViewTestResource) mvAsyncBackfillTable(rtc *ResourceTe
 	%s
 
 	resource "%s" "%s" {
-		name                 = "%s"
-		database_name        = "%s"
-		source_table_name    = adx_table.%s.name
-		backfill             = true
-		async     			 = true
-		query                = "${adx_table.%s.name} %s | summarize arg_max(score,*) by team"
+		name                 					= "%s"
+		database_name        					= "%s"
+		source_table_name    					= adx_table.%s.name
+		backfill             					= true
+		async     			 					= true
+		query                					= "${adx_table.%s.name} %s | summarize arg_max(score,*) by team"
+		max_source_records_for_single_ingest 	= 3000000
+		concurrency								= 2
 
 		timeouts {
 			create = "1m"

--- a/docs/resources/adx_materialized_view.md
+++ b/docs/resources/adx_materialized_view.md
@@ -37,6 +37,8 @@ resource "adx_materialized_view" "test" {
 - **allow_mv_without_rls** (Boolean, Optional) Enables `allowMaterializedViewsWithoutRowLevelSecurity` flag during policy creation
 - **folder** (String, Optional) Name of the folder in which to place this entity
 - **docstring** (String, Optional) Free text describing the entity to be added. This string is presented in various UX settings next to the entity names.
+- **max_source_records_for_single_ingest** (Int, Optional) By default, the number of source records in each ingest operation during backfill is 2 million per node. You can change this default by setting this property to the desired number of records. (The value is the total number of records in each ingest operation.)
+- **concurrency** (Int, Optional) The ingest operations, running as part of the backfill process, run concurrently. By default, concurrency is min(number_of_nodes * 2, 5).
 - **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
 
 `cluster` Configuration block for connection details about the target ADX cluster 


### PR DESCRIPTION
Ref: https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/materialized-views/materialized-view-create#backfill-a-materialized-view

These parameters can be useful in cases where backfill=true. 

Hopefully I did everything correct. Feel free to edit so I can learn. Thank you. 

