### PR TITLE
feat: add terraform import functionality to adx_function 

### DIFF
--- a/adx/resource_adx_function.go
+++ b/adx/resource_adx_function.go
@@ -29,6 +29,9 @@ func resourceADXFunction() *schema.Resource {
 		UpdateContext: resourceADXFunctionUpdate,
 		ReadContext:   resourceADXFunctionRead,
 		DeleteContext: resourceADXFunctionDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"cluster": getClusterConfigInputSchema(),

--- a/adx/resource_adx_function_test.go
+++ b/adx/resource_adx_function_test.go
@@ -51,6 +51,11 @@ func TestAccADXFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "folder", "iamafolder"),
 				),
 			},
+			{
+				ResourceName:      rtc.GetTFName(),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
Hi, 

`terraform import xxx yyy `

does not work, because the functionality is missing within the provider. 

Add the importer and adjust the test. Feel free to edit.

Thanks