### PR TITLE
Add feature: column encoding policy

### DIFF
--- a/adx/provider.go
+++ b/adx/provider.go
@@ -67,6 +67,7 @@ func Provider() *schema.Provider {
 			"adx_materialized_view_caching_policy":            resourceADXMaterializedViewCachingPolicy(),
 			"adx_materialized_view_retention_policy":          resourceADXMaterializedViewRetentionPolicy(),
 			"adx_materialized_view_row_level_security_policy": resourceADXMaterializedViewRowLevelSecurityPolicy(),
+			"adx_encoding_policy":                             resourceADXColumnEncodingPolicy(),
 		},
 	}
 

--- a/adx/resource_adx_column_encoding_policy.go
+++ b/adx/resource_adx_column_encoding_policy.go
@@ -1,0 +1,85 @@
+package adx
+
+import (
+	"context"
+	"fmt"
+
+	"encoding/json"
+
+	"github.com/favoretti/terraform-provider-adx/adx/validate"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type ColumnEncodingPolicy struct {
+	EntityIdentifier   string
+	EncodingPolicyType string
+}
+
+func resourceADXColumnEncodingPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceADXColumnEncodingPolicyCreateUpdate,
+		ReadContext:   resourceADXColumnEncodingPolicyRead,
+		UpdateContext: resourceADXColumnEncodingPolicyCreateUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cluster": getClusterConfigInputSchema(),
+			"database_name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+
+			"entity_identifier": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+
+			"encoding_policy_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Null",
+			},
+		},
+		CustomizeDiff: clusterConfigCustomDiff,
+	}
+}
+
+func resourceADXColumnEncodingPolicyCreateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	databaseName := d.Get("database_name").(string)
+	entityIdentifier := d.Get("entity_identifier").(string)
+	encodingPolicyType := d.Get("encoding_policy_type").(string)
+
+	createStatement := fmt.Sprintf(".alter column (%s) policy encoding type='%s'", entityIdentifier, encodingPolicyType)
+
+	if err := createADXPolicy(ctx, d, meta, "column", "encoding", databaseName, entityIdentifier, createStatement); err != nil {
+		return diag.Errorf("%+v", err)
+	}
+
+	return resourceADXColumnEncodingPolicyRead(ctx, d, meta)
+}
+
+func resourceADXColumnEncodingPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	id, resultSet, diags := readADXPolicy(ctx, d, meta, "column", "encoding")
+	if diags.HasError() || resultSet == nil || len(resultSet) == 0 {
+		return diags
+	}
+
+	var policy ColumnEncodingPolicy
+	if err := json.Unmarshal([]byte(resultSet[0].Policy), &policy); err != nil {
+		return diag.Errorf("error parsing policy encoding for Column %q (Database %q): %+v", id.Name, id.DatabaseName, err)
+	}
+
+	d.Set("column_name", id.Name)
+	d.Set("database_name", id.DatabaseName)
+	d.Set("entity_identifier", policy.EntityIdentifier)
+	d.Set("encoding_policy_type", policy.EncodingPolicyType)
+
+	return diags
+}

--- a/adx/resource_adx_column_encoding_policy_test.go
+++ b/adx/resource_adx_column_encoding_policy_test.go
@@ -1,0 +1,72 @@
+package adx
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+type ADXColumnEncodingPolicyTestResource struct{}
+
+func TestAccADXColumnEncodingPolicy_basic(t *testing.T) {
+	var entity ColumnEncodingPolicy
+	r := ADXColumnEncodingPolicyTestResource{}
+	rtcBuilder := BuildResourceTestContext[ColumnEncodingPolicy]()
+	rtc, _ := rtcBuilder.Test(t).Type("adx_column_encoding_policy").
+		DatabaseName("test-db").
+		EntityType("encoding").
+		ReadStatementFunc(GetAccTestPolicyReadStatementFunc()).Build()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(rtc, fmt.Sprintf("%s.f1", rtc.EntityName), "BigObject"),
+				Check: resource.ComposeTestCheckFunc(
+					rtc.GetTestCheckEntityExists(&entity),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "entity_identifier", fmt.Sprintf("%s.f1", rtc.EntityName)),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "encoding_policy_type", "BigObject"),
+				),
+			},
+			{
+				Config: r.basic(rtc, "00:05:00", "200"),
+				Check: resource.ComposeTestCheckFunc(
+					rtc.GetTestCheckEntityExists(&entity),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "entity_identifier", fmt.Sprintf("%s.f1", rtc.EntityName)),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "encoding_policy_type", "BigObject"),
+				),
+			},
+			{
+				ResourceName:      rtc.GetTFName(),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func (this ADXColumnEncodingPolicyTestResource) basic(rtc *ResourceTestContext[ColumnEncodingPolicy], entityIdentifier string, encodingPolicyType string) string {
+	return fmt.Sprintf(`
+	%s
+
+	resource "%s" %s {
+		database_name         	= "%s"
+		entity_identifier 		= "%s"
+		encoding_policy_type   	= "%s"
+	}
+	`, this.template(rtc), rtc.Type, rtc.Label, rtc.DatabaseName, entityIdentifier, encodingPolicyType)
+}
+
+func (this ADXColumnEncodingPolicyTestResource) template(rtc *ResourceTestContext[ColumnEncodingPolicy]) string {
+	return fmt.Sprintf(`
+	resource "adx_table" "test" {
+		database_name = "%s"
+		name          = "%s"
+		table_schema  = "f1:dynamic,f2:string,f4:string,f3:int"
+	}
+	`, rtc.DatabaseName, rtc.EntityName)
+}

--- a/docs/resources/adx_column_encoding_policy.md
+++ b/docs/resources/adx_column_encoding_policy.md
@@ -1,0 +1,43 @@
+---
+page_title: "adx_column_encoding_policy Resource - terraform-provider-adx"
+subcategory: ""
+description: |-
+  Manages the encoding policy of a column in ADX.
+---
+
+# Resource `adx_column_encoding_policy`
+
+Manages encoding policy for a column in ADX.
+
+See: [ADX - encoding Policy](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/encoding-policy)
+
+## Example Usage
+
+```terraform
+
+resource "adx_table" "test" {
+  name          = "Test1"
+  database_name = "test-db"
+  table_schema  = "f1:dynamic,f2:string,f3:int"
+}
+
+resource "adx_column_encoding_policy" "test" {
+  database_name         = "test-db"
+  entity_identifier     = "Test1.f1"
+  encoding_policy_type  = "BigObject"
+}
+
+```
+
+## Argument Reference
+
+- **database_name** (String, Required) Database name that the target table is in
+- **entity_identifier** (String, Required) The identifier for the column.
+- **encoding_policy_type** (String, Optional) The type of the encoding policy to apply to the specified column. If you omit the type, the existing encoding policy profile is cleared reset to the default value.
+
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- **id** - The ID of this resource.

--- a/docs/resources/adx_column_encoding_policy.md
+++ b/docs/resources/adx_column_encoding_policy.md
@@ -31,7 +31,7 @@ resource "adx_column_encoding_policy" "test" {
 
 ## Argument Reference
 
-- **database_name** (String, Required) Database name that the target table is in
+- **database_name** (String, Required) Database name that the target column is in
 - **entity_identifier** (String, Required) The identifier for the column.
 - **encoding_policy_type** (String, Optional) The type of the encoding policy to apply to the specified column. If you omit the type, the existing encoding policy profile is cleared reset to the default value.
 


### PR DESCRIPTION
- implement the possibility to alter encoding policy of columns


There is no delete of the encoding policy within the adx. 

Hopefully I implemented the test correctly. 

Thank you 


@slwbuild @favoretti 