### PR TITLE
typo adx column encoding policy

### DIFF
--- a/adx/provider.go
+++ b/adx/provider.go
@@ -67,7 +67,7 @@ func Provider() *schema.Provider {
 			"adx_materialized_view_caching_policy":            resourceADXMaterializedViewCachingPolicy(),
 			"adx_materialized_view_retention_policy":          resourceADXMaterializedViewRetentionPolicy(),
 			"adx_materialized_view_row_level_security_policy": resourceADXMaterializedViewRowLevelSecurityPolicy(),
-			"adx_encoding_policy":                             resourceADXColumnEncodingPolicy(),
+			"adx_column_encoding_policy":                      resourceADXColumnEncodingPolicy(),
 		},
 	}
 


### PR DESCRIPTION
- a little typo within the provider resource naming