### PR TITLE
add policy.Profile to read encoding policy type on Read within enc. pol.

### DIFF
--- a/adx/resource_adx_column_encoding_policy.go
+++ b/adx/resource_adx_column_encoding_policy.go
@@ -12,8 +12,8 @@ import (
 )
 
 type ColumnEncodingPolicy struct {
-	EntityIdentifier   string
-	EncodingPolicyType string
+	EntityIdentifier string
+	Profile          string
 }
 
 func resourceADXColumnEncodingPolicy() *schema.Resource {
@@ -79,7 +79,7 @@ func resourceADXColumnEncodingPolicyRead(ctx context.Context, d *schema.Resource
 
 	d.Set("entity_identifier", id.Name)
 	d.Set("database_name", id.DatabaseName)
-	d.Set("encoding_policy_type", policy.EncodingPolicyType)
+	d.Set("encoding_policy_type", policy.Profile)
 
 	return diags
 }


### PR DESCRIPTION
.show column tablename.column policy encoding returns a column "Policy" with JSON (not in an array)

`{
  "BlockCompressionAlgorithm": "LZ4",
  "BlockCompressionLevel": 2,
  "BuildColumnTermIndex": false,
  "MinTermLength": 4,
  "BuildColumnSubstringIndex": false,
  "MinSubstringLength": 4,
  "BuildColumnRangeIndex": true,
  "ColumnIndexTextTokenizerName": "trivial",
  "BuildSegmentTermIndex": false,
  "BuildSegmentRangeIndex": false,
  "BlockFixedValueCount": -1,
  "BlockMaxInputSize": 131072,
  "BlockMaxValueCount": 512,
  "SegmentMaxValueCount": 1048576,
  "SegmentMaxBlockCount": -1,
  "SegmentMaxEncodedSize": -1,
  "ExtentMaxRecordCount": -1,
  "ExtentMaxEncodedSize": -1,
  "ColumnIndexRangeGranularity": 0,
  "MaxValueSize": 33554432,
  "MaxSketchCardinality": 1024,
  "EncodingPolicyOrigin": "Admin",
  "Profile": "BigObject32",
  "ShardFieldCompressionCodec": "LZ4",
  "ShardFieldCompressionLevel": "high",
  "ShardFieldBlockMaxCount": 512,
  "ShardFieldBlockMaxSize": 131072,
  "ShardFieldTokenizer": "empty",
  "ShardFieldEmbedPresence": false,
  "ShardFieldIndexPositionEncoding": "DEFAULT"
}`

The "Profile" attribute is the one for the encoding policy type. 