### PR TITLE
Add skipvalidation parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,47 @@
+## v0.0.31
+
+* Bugfix: add `adx_table_ingestion_time_policy` to provider init
+
+## v0.0.30
+
+* Add new resources: continuous export and external table
+
+## v0.0.29
+
+* Bugfix for `adx_column_encoding_policy`
+
+## v0.0.28
+
+* Bugfix for `adx_column_encoding_policy`
+
+## v0.0.27
+
+* Bugfix for `adx_column_encoding_policy`
+
+## v0.0.26
+
+* Add feature: delete for column encoding policy
+
+## v0.0.24
+
+* Add feature: column encoding policy
+
+## v0.0.23
+
+* update autoUpdateSchema property for given MVs
+* Issue #50 - Missing option - ingestiontime
+* New resource: `adx_table_ingestion_time_policy`
+
+## v0.0.22
+
+* `adx_function` supports imports now (#48)
+
+## v0.0.21
+
+* Add concurrency and maxSourceRecordsForSingleIngest as optional params to MVs (#42)
+* add concurrency and maxSourceRecordsForSingleIngest as optional parameter to mv
+* add new predicate and augmented tests
+
 ## v0.0.20
 
 * Fixed issue #35. Async materialized view creation now properly polls ADX operations to wait for completion

--- a/adx/provider.go
+++ b/adx/provider.go
@@ -53,20 +53,28 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"adx_table":                                       resourceADXTable(),
-			"adx_table_mapping":                               resourceADXTableMapping(),
-			"adx_table_ingestion_batching_policy":             resourceADXTableIngestionBatchingPolicy(),
-			"adx_table_retention_policy":                      resourceADXTableRetentionPolicy(),
-			"adx_table_row_level_security_policy":             resourceADXTableRowLevelSecurityPolicy(),
-			"adx_table_partitioning_policy":                   resourceADXTablePartitioningPolicy(),
-			"adx_table_caching_policy":                        resourceADXTableCachingPolicy(),
-			"adx_table_update_policy":                         resourceADXTableUpdatePolicy(),
-			"adx_table_streaming_ingestion_policy":            resourceADXTableStreamingIngestionPolicy(),
-			"adx_function":                                    resourceADXFunction(),
+			"adx_column_encoding_policy": resourceADXColumnEncodingPolicy(),
+
+			"adx_external_table": resourceADXExternalTable(),
+
+			"adx_function": resourceADXFunction(),
+
 			"adx_materialized_view":                           resourceADXMaterializedView(),
 			"adx_materialized_view_caching_policy":            resourceADXMaterializedViewCachingPolicy(),
 			"adx_materialized_view_retention_policy":          resourceADXMaterializedViewRetentionPolicy(),
 			"adx_materialized_view_row_level_security_policy": resourceADXMaterializedViewRowLevelSecurityPolicy(),
+
+			"adx_table":                            resourceADXTable(),
+			"adx_table_caching_policy":             resourceADXTableCachingPolicy(),
+			"adx_table_continuous_export":          resourceADXTableContinuousExport(),
+			"adx_table_ingestion_batching_policy":  resourceADXTableIngestionBatchingPolicy(),
+			"adx_table_ingestion_time_policy":      resourceADXTableIngestionTimePolicy(),
+			"adx_table_mapping":                    resourceADXTableMapping(),
+			"adx_table_partitioning_policy":        resourceADXTablePartitioningPolicy(),
+			"adx_table_retention_policy":           resourceADXTableRetentionPolicy(),
+			"adx_table_row_level_security_policy":  resourceADXTableRowLevelSecurityPolicy(),
+			"adx_table_streaming_ingestion_policy": resourceADXTableStreamingIngestionPolicy(),
+			"adx_table_update_policy":              resourceADXTableUpdatePolicy(),
 		},
 	}
 

--- a/adx/resource_adx_column_encoding_policy.go
+++ b/adx/resource_adx_column_encoding_policy.go
@@ -1,0 +1,97 @@
+package adx
+
+import (
+	"context"
+	"fmt"
+
+	"encoding/json"
+
+	"github.com/favoretti/terraform-provider-adx/adx/validate"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type ColumnEncodingPolicy struct {
+	EntityIdentifier string
+	Profile          string
+}
+
+func resourceADXColumnEncodingPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceADXColumnEncodingPolicyCreateUpdate,
+		ReadContext:   resourceADXColumnEncodingPolicyRead,
+		UpdateContext: resourceADXColumnEncodingPolicyCreateUpdate,
+		DeleteContext: resourceADXColumnEncodingPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cluster": getClusterConfigInputSchema(),
+			"database_name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+
+			"entity_identifier": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+
+			"encoding_policy_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Null",
+			},
+		},
+		CustomizeDiff: clusterConfigCustomDiff,
+	}
+}
+
+func resourceADXColumnEncodingPolicyCreateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	databaseName := d.Get("database_name").(string)
+	entityIdentifier := d.Get("entity_identifier").(string)
+	encodingPolicyType := d.Get("encoding_policy_type").(string)
+
+	createStatement := fmt.Sprintf(".alter column %s policy encoding type='%s'", entityIdentifier, encodingPolicyType)
+
+	if err := createADXPolicy(ctx, d, meta, "column", "encoding", databaseName, entityIdentifier, createStatement); err != nil {
+		return diag.Errorf("%+v", err)
+	}
+
+	return resourceADXColumnEncodingPolicyRead(ctx, d, meta)
+}
+
+func resourceADXColumnEncodingPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	id, resultSet, diags := readADXPolicy(ctx, d, meta, "column", "encoding")
+	if diags.HasError() || resultSet == nil || len(resultSet) == 0 {
+		return diags
+	}
+
+	var policy ColumnEncodingPolicy
+	if err := json.Unmarshal([]byte(resultSet[0].Policy), &policy); err != nil {
+		return diag.Errorf("error parsing policy encoding for Column %q (Database %q): %+v", id.Name, id.DatabaseName, err)
+	}
+
+	d.Set("entity_identifier", id.Name)
+	d.Set("database_name", id.DatabaseName)
+	d.Set("encoding_policy_type", policy.Profile)
+
+	return diags
+}
+
+func resourceADXColumnEncodingPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	entityIdentifier := d.Get("entity_identifier").(string)
+
+	clusterConfig := getAndExpandClusterConfigWithDefaults(ctx, d, meta)
+	id, err := parseADXPolicyID(d.Id())
+	if err != nil {
+		return diag.Errorf("could not delete adx policy due to error parsing ID: %+v", err)
+	}
+
+	return deleteADXEntity(ctx, d, meta, clusterConfig, id.DatabaseName, fmt.Sprintf(".alter column %s policy encoding type='Null'", entityIdentifier)) //Encoding policy can't be deleted. So set it back to default.
+}

--- a/adx/resource_adx_column_encoding_policy_test.go
+++ b/adx/resource_adx_column_encoding_policy_test.go
@@ -1,0 +1,72 @@
+package adx
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+type ADXColumnEncodingPolicyTestResource struct{}
+
+func TestAccADXColumnEncodingPolicy_basic(t *testing.T) {
+	var entity ColumnEncodingPolicy
+	r := ADXColumnEncodingPolicyTestResource{}
+	rtcBuilder := BuildResourceTestContext[ColumnEncodingPolicy]()
+	rtc, _ := rtcBuilder.Test(t).Type("adx_column_encoding_policy").
+		DatabaseName("test-db").
+		EntityType("encoding").
+		ReadStatementFunc(GetAccTestPolicyReadStatementFunc()).Build()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(rtc, fmt.Sprintf("%s.f1", rtc.EntityName), "BigObject"),
+				Check: resource.ComposeTestCheckFunc(
+					rtc.GetTestCheckEntityExists(&entity),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "entity_identifier", fmt.Sprintf("%s.f1", rtc.EntityName)),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "encoding_policy_type", "BigObject"),
+				),
+			},
+			{
+				Config: r.basic(rtc, "00:05:00", "200"),
+				Check: resource.ComposeTestCheckFunc(
+					rtc.GetTestCheckEntityExists(&entity),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "entity_identifier", fmt.Sprintf("%s.f1", rtc.EntityName)),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "encoding_policy_type", "BigObject"),
+				),
+			},
+			{
+				ResourceName:      rtc.GetTFName(),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func (this ADXColumnEncodingPolicyTestResource) basic(rtc *ResourceTestContext[ColumnEncodingPolicy], entityIdentifier string, encodingPolicyType string) string {
+	return fmt.Sprintf(`
+	%s
+
+	resource "%s" %s {
+		database_name         	= "%s"
+		entity_identifier 		= "%s"
+		encoding_policy_type   	= "%s"
+	}
+	`, this.template(rtc), rtc.Type, rtc.Label, rtc.DatabaseName, entityIdentifier, encodingPolicyType)
+}
+
+func (this ADXColumnEncodingPolicyTestResource) template(rtc *ResourceTestContext[ColumnEncodingPolicy]) string {
+	return fmt.Sprintf(`
+	resource "adx_table" "test" {
+		database_name = "%s"
+		name          = "%s"
+		table_schema  = "f1:dynamic,f2:string,f4:string,f3:int"
+	}
+	`, rtc.DatabaseName, rtc.EntityName)
+}

--- a/adx/resource_adx_external_table.go
+++ b/adx/resource_adx_external_table.go
@@ -1,0 +1,271 @@
+package adx
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/favoretti/terraform-provider-adx/adx/validate"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type ADXExternalTable struct {
+	Name              string
+	ConnectionStrings string
+	Partitions        string
+	PathFormat        string
+	Folder            string
+	Properties        string
+}
+
+func resourceADXExternalTable() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceADXExternalTableCreateUpdate,
+		UpdateContext: resourceADXExternalTableCreateUpdate,
+		ReadContext:   resourceADXExternalTableRead,
+		DeleteContext: resourceADXExternalTableDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cluster": getClusterConfigInputSchema(),
+			"database_name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+
+			"name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+
+			"data_format": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+
+			"storage_connection_string": {
+				Type:             schema.TypeString,
+				Required:         true,
+				Sensitive:        true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+
+			"schema": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+
+			"kind": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "storage",
+			},
+
+			"partitions": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "jsonencode([])",
+			},
+
+			"path_format": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"folder": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"doc_string": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"compressed": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"include_headers": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "All",
+			},
+
+			"name_prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"file_extension": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"encoding": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "UTF8NoBOM",
+			},
+
+			"sample_uris": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"files_preview": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"validate_not_empty": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"dry_run": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+		CustomizeDiff: clusterConfigCustomDiff,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+	}
+}
+
+func resourceADXExternalTableCreateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clusterConfig := getAndExpandClusterConfigWithDefaults(ctx, d, meta)
+	name := d.Get("name").(string)
+	databaseName := d.Get("database_name").(string)
+	dataFormat := d.Get("data_format").(string)
+	storageConnectionString := d.Get("storage_connection_string").(string)
+	schema := d.Get("schema").(string)
+	partitions := d.Get("partitions").(string)
+	pathFormat := d.Get("path_format").(string)
+	kind := d.Get("kind").(string)
+
+	var withParams []string
+
+	if folder, ok := d.GetOk("folder"); ok {
+		withParams = append(withParams, fmt.Sprintf("folder=%s", folder.(string)))
+	}
+	if docString, ok := d.GetOk("doc_string"); ok {
+		withParams = append(withParams, fmt.Sprintf("docString=%s", docString.(string)))
+	}
+	if compressed, ok := d.GetOk("compressed"); ok {
+		withParams = append(withParams, fmt.Sprintf("compressed=%t", compressed.(bool)))
+	}
+	if includeHeaders, ok := d.GetOk("include_headers"); ok {
+		withParams = append(withParams, fmt.Sprintf("includeHeaders=%s", includeHeaders.(string)))
+	}
+	if namePrefix, ok := d.GetOk("name_prefix"); ok {
+		withParams = append(withParams, fmt.Sprintf("namePrefix=%s", namePrefix.(string)))
+	}
+	if fileExtension, ok := d.GetOk("file_extension"); ok {
+		withParams = append(withParams, fmt.Sprintf("fileExtension='%s'", fileExtension.(string)))
+	}
+	if encoding, ok := d.GetOk("encoding"); ok {
+		withParams = append(withParams, fmt.Sprintf("encoding='%s'", encoding.(string)))
+	}
+	if sampleUris, ok := d.GetOk("sample_uris"); ok {
+		withParams = append(withParams, fmt.Sprintf("sampleUris=%t", sampleUris.(bool)))
+	}
+	if filesPreview, ok := d.GetOk("files_preview"); ok {
+		withParams = append(withParams, fmt.Sprintf("filesPreview=%t", filesPreview.(bool)))
+	}
+	if validateNotEmpty, ok := d.GetOk("validate_not_empty"); ok {
+		withParams = append(withParams, fmt.Sprintf("validateNotEmpty=%t", validateNotEmpty.(bool)))
+	}
+	if dryRun, ok := d.GetOk("dry_run"); ok {
+		withParams = append(withParams, fmt.Sprintf("dryRun=%t", dryRun.(bool)))
+	}
+
+	withClause := ""
+	if len(withParams) > 0 {
+		withClause = fmt.Sprintf("with(%s)", strings.Join(withParams, ", "))
+	}
+
+	createStatement := ""
+	if len(partitions) > 0 && len(pathFormat) > 0 {
+		createStatement = fmt.Sprintf(".create-or-alter external table %s (%s) kind = %s partition by (%s) pathformat = (%s) dataformat = %s ('%s') %s", name, schema, kind, partitions, pathFormat, dataFormat, storageConnectionString, withClause)
+	} else if len(partitions) > 0 && len(pathFormat) == 0 {
+		createStatement = fmt.Sprintf(".create-or-alter external table %s (%s) kind = %s partition by (%s) dataformat = %s ('%s') %s", name, schema, kind, partitions, dataFormat, storageConnectionString, withClause)
+	} else if len(partitions) == 0 && len(pathFormat) > 0 {
+		createStatement = fmt.Sprintf(".create-or-alter external table %s (%s) kind = %s pathformat = (%s) dataformat = %s ('%s') %s", name, schema, kind, pathFormat, dataFormat, storageConnectionString, withClause)
+	} else {
+		createStatement = fmt.Sprintf(".create-or-alter external table %s (%s) kind = %s dataformat = %s ('%s') %s", name, schema, kind, dataFormat, storageConnectionString, withClause)
+	}
+
+	_, err := queryADXMgmt(ctx, meta, clusterConfig, databaseName, createStatement)
+	if err != nil {
+		return diag.Errorf("error creating external table %s (Database %q): %+v", name, databaseName, err)
+	}
+
+	client, err := getADXClient(meta, clusterConfig)
+	if err != nil {
+		return diag.Errorf("error creating adx client connection: %+v", err)
+	}
+	d.SetId(buildADXResourceId(client.Endpoint(), databaseName, "externaltable", name))
+
+	return resourceADXExternalTableRead(ctx, d, meta)
+}
+
+func resourceADXExternalTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clusterConfig := getAndExpandClusterConfigWithDefaults(ctx, d, meta)
+
+	id, err := parseADXExternalTableID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	showCommand := fmt.Sprintf(".show external table %s ", id.Name)
+
+	resultSet, diags := readADXEntity[ADXExternalTable](ctx, meta, clusterConfig, id, showCommand, "external table")
+	if diags.HasError() {
+		return diags
+	}
+
+	if len(resultSet) < 1 {
+		d.SetId("")
+	} else {
+
+		d.Set("name", id.Name)
+		d.Set("database_name", id.DatabaseName)
+		d.Set("storage_connection_string", resultSet[0].ConnectionStrings)
+		d.Set("partitions", resultSet[0].Partitions)
+		d.Set("path_format", resultSet[0].PathFormat)
+		d.Set("folder", resultSet[0].Folder)
+		d.Set("properties", resultSet[0].Properties)
+
+	}
+
+	return diags
+}
+
+func resourceADXExternalTableDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clusterConfig := getAndExpandClusterConfigWithDefaults(ctx, d, meta)
+
+	id, err := parseADXExternalTableID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return deleteADXEntity(ctx, d, meta, clusterConfig, id.DatabaseName, fmt.Sprintf(".drop external table %s", id.Name))
+}
+
+func parseADXExternalTableID(input string) (*adxResourceId, error) {
+	return parseADXResourceID(input, 4, 0, 1, 2, 3)
+}

--- a/adx/resource_adx_function.go
+++ b/adx/resource_adx_function.go
@@ -113,7 +113,7 @@ func resourceADXFunctionCreateUpdate(ctx context.Context, d *schema.ResourceData
 		withParams = append(withParams, fmt.Sprintf("folder='%s'", folder))
 	}
 	if skip_validation, ok := d.Get("skip_validation").(bool); ok {
-		withParams = append(withParams, fmt.Sprintf("skipvalidation='%s'", strconv.FormatBool(skip_validation)))
+		withParams = append(withParams, fmt.Sprintf("skipvalidation=%s", strconv.FormatBool(skip_validation)))
 	}
 
 	withClause := ""

--- a/adx/resource_adx_function.go
+++ b/adx/resource_adx_function.go
@@ -16,11 +16,12 @@ import (
 )
 
 type ADXFunction struct {
-	Name       string
-	Parameters string
-	Body       string
-	Folder     string
-	DocString  string
+	Name           string
+	Parameters     string
+	Body           string
+	Folder         string
+	DocString      string
+	SkipValidation bool
 }
 
 func resourceADXFunction() *schema.Resource {
@@ -73,6 +74,12 @@ func resourceADXFunction() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
+			"skipvalidation": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 		CustomizeDiff: clusterConfigCustomDiff,
 	}
@@ -104,6 +111,9 @@ func resourceADXFunctionCreateUpdate(ctx context.Context, d *schema.ResourceData
 	}
 	if folder, ok := d.GetOk("folder"); ok {
 		withParams = append(withParams, fmt.Sprintf("folder='%s'", folder))
+	}
+	if skipvalidation, ok := d.GetOk("skipvalidation"); ok {
+		withParams = append(withParams, fmt.Sprintf("skipvalidation=%s", skipvalidation))
 	}
 
 	withClause := ""

--- a/adx/resource_adx_function.go
+++ b/adx/resource_adx_function.go
@@ -31,6 +31,9 @@ func resourceADXFunction() *schema.Resource {
 		UpdateContext: resourceADXFunctionUpdate,
 		ReadContext:   resourceADXFunctionRead,
 		DeleteContext: resourceADXFunctionDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"cluster": getClusterConfigInputSchema(),

--- a/adx/resource_adx_function.go
+++ b/adx/resource_adx_function.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"strconv"
 
 	"github.com/Azure/azure-kusto-go/kusto"
 	"github.com/Azure/azure-kusto-go/kusto/unsafe"
@@ -75,10 +76,9 @@ func resourceADXFunction() *schema.Resource {
 				Optional: true,
 			},
 
-			"skipvalidation": {
+			"skip_validation": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
 			},
 		},
 		CustomizeDiff: clusterConfigCustomDiff,
@@ -112,8 +112,8 @@ func resourceADXFunctionCreateUpdate(ctx context.Context, d *schema.ResourceData
 	if folder, ok := d.GetOk("folder"); ok {
 		withParams = append(withParams, fmt.Sprintf("folder='%s'", folder))
 	}
-	if skipvalidation, ok := d.GetOk("skipvalidation"); ok {
-		withParams = append(withParams, fmt.Sprintf("skipvalidation=%s", skipvalidation))
+	if skip_validation, ok := d.Get("skip_validation").(bool); ok {
+		withParams = append(withParams, fmt.Sprintf("skipvalidation='%s'", strconv.FormatBool(skip_validation)))
 	}
 
 	withClause := ""

--- a/adx/resource_adx_function_test.go
+++ b/adx/resource_adx_function_test.go
@@ -51,6 +51,11 @@ func TestAccADXFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rtc.GetTFName(), "folder", "iamafolder"),
 				),
 			},
+			{
+				ResourceName:      rtc.GetTFName(),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/adx/resource_adx_materialized_view.go
+++ b/adx/resource_adx_materialized_view.go
@@ -162,7 +162,7 @@ func resourceADXMaterializedViewCreateUpdate(ctx context.Context, d *schema.Reso
 	if updateExtentsCreationTime, ok := d.GetOk("update_extents_creation_time"); ok && new {
 		withParams = append(withParams, fmt.Sprintf("UpdateExtentsCreationTime=%t", updateExtentsCreationTime.(bool)))
 	}
-	if autoUpdateSchema, ok := d.GetOk("auto_update_schema"); ok && new {
+	if autoUpdateSchema, ok := d.GetOk("auto_update_schema"); ok {
 		withParams = append(withParams, fmt.Sprintf("autoUpdateSchema=%t", autoUpdateSchema.(bool)))
 	}
 	if effectiveDateTime, ok := d.GetOk("effective_date_time"); ok && new {

--- a/adx/resource_adx_table_continuous_export.go
+++ b/adx/resource_adx_table_continuous_export.go
@@ -1,0 +1,204 @@
+package adx
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/favoretti/terraform-provider-adx/adx/validate"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type ADXContinuousExport struct {
+	Name string
+}
+
+func resourceADXTableContinuousExport() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceADXContinuousExportCreateUpdate,
+		UpdateContext: resourceADXContinuousExportCreateUpdate,
+		ReadContext:   resourceADXContinuousExportRead,
+		DeleteContext: resourceADXContinuousExportDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cluster": getClusterConfigInputSchema(),
+			"database_name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+
+			"name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+
+			"external_table_name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+
+			"query": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+
+			"interval_between_runs": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "10h",
+			},
+
+			"forced_latency": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"size_limit": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  100000000, //100 MB
+			},
+
+			"distributed": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"parquet_row_group_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  100000,
+			},
+
+			"use_native_parquet_writer": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"managed_identity": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"is_disabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+		CustomizeDiff: clusterConfigCustomDiff,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+	}
+}
+
+func resourceADXContinuousExportCreateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clusterConfig := getAndExpandClusterConfigWithDefaults(ctx, d, meta)
+	name := d.Get("name").(string)
+	databaseName := d.Get("database_name").(string)
+	query := d.Get("query").(string)
+	externalTableName := d.Get("external_table_name").(string)
+
+	var withParams []string
+
+	if intervalBetweenRuns, ok := d.GetOk("interval_between_runs"); ok {
+		withParams = append(withParams, fmt.Sprintf("intervalBetweenRuns='%s'", intervalBetweenRuns.(string)))
+	}
+	if forcedLatency, ok := d.GetOk("forced_latency"); ok {
+		withParams = append(withParams, fmt.Sprintf("forcedLatency=%s", forcedLatency.(string)))
+	}
+	if sizeLimit, ok := d.GetOk("size_limit"); ok {
+		withParams = append(withParams, fmt.Sprintf("sizeLimit=%d", sizeLimit.(int)))
+	}
+	if distributed, ok := d.GetOk("distributed"); ok {
+		withParams = append(withParams, fmt.Sprintf("distributed=%t", distributed.(bool)))
+	}
+	if parquetRowGroupSize, ok := d.GetOk("parquet_row_group_size"); ok {
+		withParams = append(withParams, fmt.Sprintf("parquetRowGroupSize=%d", parquetRowGroupSize.(int)))
+	}
+	if useNativeParquetWriter, ok := d.GetOk("use_native_parquet_writer"); ok {
+		withParams = append(withParams, fmt.Sprintf("useNativeParquetWriter='%s'", useNativeParquetWriter.(string)))
+	}
+	if managedIdentity, ok := d.GetOk("managed_identity"); ok {
+		withParams = append(withParams, fmt.Sprintf("managedIdentity='%s'", managedIdentity.(string)))
+	}
+	if isDisabled, ok := d.GetOk("is_disabled"); ok {
+		withParams = append(withParams, fmt.Sprintf("isDisabled=%t", isDisabled.(bool)))
+	}
+
+	withClause := ""
+	if len(withParams) > 0 {
+		withClause = fmt.Sprintf("with(%s)", strings.Join(withParams, ", "))
+	}
+
+	createStatement := fmt.Sprintf(".create-or-alter continuous-export %s to table %s %s <| %s", name, externalTableName, withClause, query)
+	_, err := queryADXMgmt(ctx, meta, clusterConfig, databaseName, createStatement)
+	if err != nil {
+		return diag.Errorf("error creating continuous-export %s (Database %q): %+v", name, databaseName, err)
+	}
+
+	client, err := getADXClient(meta, clusterConfig)
+	if err != nil {
+		return diag.Errorf("error creating adx client connection: %+v", err)
+	}
+	d.SetId(buildADXResourceId(client.Endpoint(), databaseName, "continuousexport", name))
+
+	return resourceADXContinuousExportRead(ctx, d, meta)
+}
+
+func resourceADXContinuousExportRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clusterConfig := getAndExpandClusterConfigWithDefaults(ctx, d, meta)
+
+	id, err := parseADXContinuousExportID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	showCommand := fmt.Sprintf(".show continuous-export %s | project Name, ExternalTableName, Query", id.Name)
+
+	resultSet, diags := readADXEntity[ADXContinuousExport](ctx, meta, clusterConfig, id, showCommand, "continuous-export")
+	if diags.HasError() {
+		return diags
+	}
+
+	if len(resultSet) < 1 {
+		d.SetId("")
+	} else {
+
+		d.Set("name", id.Name)
+		d.Set("database_name", id.DatabaseName)
+
+	}
+
+	return diags
+}
+
+func resourceADXContinuousExportDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clusterConfig := getAndExpandClusterConfigWithDefaults(ctx, d, meta)
+
+	id, err := parseADXContinuousExportID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return deleteADXEntity(ctx, d, meta, clusterConfig, id.DatabaseName, fmt.Sprintf(".drop continuous-export %s", id.Name))
+}
+
+func parseADXContinuousExportID(input string) (*adxResourceId, error) {
+	return parseADXResourceID(input, 4, 0, 1, 2, 3)
+}

--- a/adx/resource_adx_table_ingestion_time_policy.go
+++ b/adx/resource_adx_table_ingestion_time_policy.go
@@ -1,0 +1,94 @@
+package adx
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"encoding/json"
+
+	"github.com/favoretti/terraform-provider-adx/adx/validate"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type IngestionTimePolicy struct {
+	IsEnabled bool
+}
+
+func resourceADXTableIngestionTimePolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceADXTableIngestionTimeCreateUpdate,
+		ReadContext:   resourceADXTableIngestionTimeRead,
+		DeleteContext: resourceADXTableIngestionTimeDelete,
+		UpdateContext: resourceADXTableIngestionTimeCreateUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cluster": getClusterConfigInputSchema(),
+			"database_name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+
+			"table_name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+		},
+		CustomizeDiff: clusterConfigCustomDiff,
+	}
+}
+
+func resourceADXTableIngestionTimeCreateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	tableName := d.Get("table_name").(string)
+	databaseName := d.Get("database_name").(string)
+	enabled := d.Get("enabled").(bool)
+
+	enabledString := strconv.FormatBool(enabled)
+
+	createStatement := fmt.Sprintf(".alter table %s policy ingestiontime %s", tableName, enabledString)
+
+	if err := createADXPolicy(ctx, d, meta, "table", "ingestiontime", databaseName, tableName, createStatement); err != nil {
+		return diag.Errorf("%+v", err)
+	}
+
+	return resourceADXTableIngestionTimeRead(ctx, d, meta)
+}
+
+func resourceADXTableIngestionTimeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	id, resultSet, diags := readADXPolicy(ctx, d, meta, "table", "ingestiontime")
+	if diags.HasError() || resultSet == nil || len(resultSet) == 0 {
+		return diags
+	}
+
+	if resultSet[0].Policy == "null" {
+		d.SetId("")
+	} else {
+
+		var policy IngestionTimePolicy
+		if err := json.Unmarshal([]byte(resultSet[0].Policy), &policy); err != nil {
+			return diag.Errorf("error parsing policy ingestiontime for Table %q (Database %q): %+v", id.Name, id.DatabaseName, err)
+		}
+
+		d.Set("table_name", id.Name)
+		d.Set("database_name", id.DatabaseName)
+		d.Set("enabled", policy.IsEnabled)
+	}
+
+	return diags
+}
+
+func resourceADXTableIngestionTimeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return deleteADXPolicy(ctx, d, meta, "table", "ingetionstime")
+}

--- a/adx/utils.go
+++ b/adx/utils.go
@@ -243,6 +243,11 @@ func isFunctionExists(ctx context.Context, meta interface{}, clusterConfig *Clus
 	return hasStatementResults(ctx, meta, clusterConfig, databaseName, showStatement, "checking if function exists")
 }
 
+func isColumnExists(ctx context.Context, meta interface{}, clusterConfig *ClusterConfig, databaseName, columnName string) (bool, error) {
+	showStatement := fmt.Sprintf(".show column %s policy encoding", columnName)
+	return hasStatementResults(ctx, meta, clusterConfig, databaseName, showStatement, "checking if column exists")
+}
+
 func isEntityExists(ctx context.Context, meta interface{}, clusterConfig *ClusterConfig, databaseName, entityType string, entityName string) (bool, error) {
 	if entityType == "table" {
 		return isTableExists(ctx, meta, clusterConfig, databaseName, entityName)
@@ -250,6 +255,8 @@ func isEntityExists(ctx context.Context, meta interface{}, clusterConfig *Cluste
 		return isMaterializedViewExists(ctx, meta, clusterConfig, databaseName, entityName)
 	} else if entityType == "function" {
 		return isFunctionExists(ctx, meta, clusterConfig, databaseName, entityName)
+	} else if entityType == "column" {
+		return isColumnExists(ctx, meta, clusterConfig, databaseName, entityName)
 	}
 	return false, fmt.Errorf("checking for existance of entity type (%s) is not yet supported", entityType)
 }

--- a/adx/utils_table.go
+++ b/adx/utils_table.go
@@ -16,6 +16,11 @@ type adxTableMappingResourceId struct {
 	adxResourceId
 }
 
+type adxTableContinuousExportResourceId struct {
+	ExternalTableName string
+	adxResourceId
+}
+
 func parseADXTableMappingID(input string) (*adxTableMappingResourceId, error) {
 	parts := strings.Split(input, "|")
 	if len(parts) != 7 {

--- a/docs/resources/adx_column_encoding_policy.md
+++ b/docs/resources/adx_column_encoding_policy.md
@@ -1,0 +1,43 @@
+---
+page_title: "adx_column_encoding_policy Resource - terraform-provider-adx"
+subcategory: ""
+description: |-
+  Manages the encoding policy of a column in ADX.
+---
+
+# Resource `adx_column_encoding_policy`
+
+Manages encoding policy for a column in ADX.
+
+See: [ADX - encoding Policy](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/encoding-policy)
+
+## Example Usage
+
+```terraform
+
+resource "adx_table" "test" {
+  name          = "Test1"
+  database_name = "test-db"
+  table_schema  = "f1:dynamic,f2:string,f3:int"
+}
+
+resource "adx_column_encoding_policy" "test" {
+  database_name         = "test-db"
+  entity_identifier     = "Test1.f1"
+  encoding_policy_type  = "BigObject"
+}
+
+```
+
+## Argument Reference
+
+- **database_name** (String, Required) Database name that the target column is in
+- **entity_identifier** (String, Required) The identifier for the column.
+- **encoding_policy_type** (String, Optional) The type of the encoding policy to apply to the specified column. If you omit the type, the existing encoding policy profile is cleared reset to the default value.
+
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- **id** - The ID of this resource.

--- a/docs/resources/adx_external_table.md
+++ b/docs/resources/adx_external_table.md
@@ -1,0 +1,84 @@
+---
+page_title: "adx_external_table Resource - terraform-provider-adx"
+subcategory: ""
+description: |-
+  Manages an update policy for a table in ADX.
+---
+
+# Resource `adx_table_continuous_export`
+
+Manages external tables in ADX.
+
+See: [ADX - External Table ](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/external-tables-azurestorage-azuredatalake)
+
+## Example Usage
+
+```terraform
+
+resource "adx_table" "test_table" {
+  name            = "my_test_table"
+  database_name   = "my_db"
+  table_schema    = "name:string,color:string,number:int"
+  merge_on_update = false
+}
+
+
+resource "adx_external_table" "test_external_table" {
+    database_name               = "my_db"
+    name                        = "et_my_test_external_table"
+    data_format                 = "csv"
+    storage_connection_string   = "your_storage_SAS_url"
+    schema                      = "name:string,color:string,number:int"
+
+    depends_on = [ adx_table.test_table ]
+}
+
+
+resource "adx_table_continuous_export" "test_cont_export" {
+  database_name         = "my_db"
+  name                  = "ce_my_test_cont_export"
+  external_table_name   = "et_my_test_external_table"
+  query                  = "my_test_table"
+  interval_between_runs = "6m"
+
+  depends_on = [ adx_external_table.test_external_table ]
+}
+
+```
+
+## Argument Reference
+
+- **name** (String, Required) An external table name that adheres to the entity names rules. An external table can't have the same name as a regular table in the same database.
+- **database_name** (String, Required) Database name within ADX that the target external table is in
+- **schema** (String, Required) The external data schema is a comma-separated list of one or more column names and data types, where each item follows the format: ColumnName : ColumnType. If the schema is unknown, use infer_storage_schema to infer the schema based on external file contents.
+- **data_format** (String, Required) The data format, which can be any of the ingestion formats. We recommend using the Parquet format for external tables to improve query and export performance, unless you use JSON paths mapping. When using an external table for export scenario, you're limited to the following formats: CSV, TSV, JSON and Parquet.
+- **storage_connection_string** (String, Required) One or more comma-separated paths to Azure Blob Storage blob containers, Azure Data Lake Gen 2 file systems or Azure Data Lake Gen 1 containers, including credentials. The external table storage type is determined by the provided connection strings. See storage connection strings.
+- **partitions** (String, Optional) A comma-separated list of columns by which the external table is partitioned. Partition column can exist in the data file itself, or as part of the file path. See partitions formatting to learn how this value should look.
+- **path_format** (String, Optional) An external data folder URI path format to use with partitions. See path format.
+- **folder** (String, Optional) Table's folder
+- **doc_string** (String, Optional) String documenting the table
+- **compressed** (Bool, Optional) If set, indicates whether the files are compressed as .gz files (used in export scenario only)
+- **include_headers** (String, Optional) For delimited text formats (CSV, TSV, ...), indicates whether files contain a header. Possible values are: All (all files contain a header), FirstFile (first file in a folder contains a header), None (no files contain a header). Default: All
+- **name_prefix** (String, Optional) If set, indicates the prefix of the files. On write operations, all files will be written with this prefix. On read operations, only files with this prefix are read.
+- **file_extension** (String, Optional) If set, indicates file extensions of the files. On write, files names will end with this suffix. On read, only files with this file extension will be read.
+- **encoding** (String, Optional) Indicates how the text is encoded: UTF8NoBOM (default) or UTF8BOM.
+- **sample_uris** (Bool, Optional) If set, the command result provides several examples of simulated external data files URI as they're expected by the external table definition. This option helps validate whether the Partitions and PathFormat parameters are defined properly.
+- **files_preview** (Bool, Optional) If set, one of the command result tables contains a preview of .show external table artifacts command. Like sampleUri, the option helps validate the Partitions and PathFormat parameters of external table definition.
+- **validate_not_empty** (Bool, Optional) If set, the connection strings are validated for having content in them. The command will fail if the specified URI location doesn't exist, or if there are insufficient permissions to access it.
+- **dry_run** (Bool, Optional) 	If set, the external table definition isn't persisted. This option is useful for validating the external table definition, especially in conjunction with the filesPreview or sampleUris parameter. 
+- **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
+
+`cluster` Configuration block for connection details about the target ADX cluster 
+
+*Note*: Any attributes specified here override the cluster config specified in the provider. Once a resource overrides an attribute specified in the provider, it will be stored explicitly as state for that resource and will not be possible to go back to the provider config unless explicitly unset.
+
+- **uri** - (String, Optional) Target ADX cluster endpoint URI, starting with `https://`
+- **client_id** - (String, Optional) The client ID for a service principal having admin access to this cluster/database.
+- **client_secret** - (String, Optional) The client secret for a service principal having admin access to this cluster/database
+- **tenant_id** - (String, Optional) Id for the tenant to which the service principal belongs
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- **id** - The ID of this resource.

--- a/docs/resources/adx_function.md
+++ b/docs/resources/adx_function.md
@@ -30,7 +30,7 @@ resource "adx_function" "test" {
 - **parameters** (String, Optional) Function parameters enclosed in parenthesis (myLimit:long)
 - **folder** (String, Optional) Name of the folder in which to place this entity
 - **docstring** (String, Optional) Free text describing the entity to be added. This string is presented in various UX settings next to the entity names.
-- **skipvalidation** (Bool, Optional) Determines whether or not to run validation logic on the function and fail the process if the function isn't valid. The default is `false`. *Note*: If a function involves cross-cluster queries and you plan to recreate the function using a [Kusto Query Language script](https://learn.microsoft.com/en-us/azure/data-explorer/database-script), set `skipvalidation` to `true`.
+- **skip_validation** (Bool, Optional) Determines whether or not to run validation logic on the function and fail the process if the function isn't valid. The default is `false`. *Note*: If a function involves cross-cluster queries and you plan to recreate the function using a [Kusto Query Language script](https://learn.microsoft.com/en-us/azure/data-explorer/database-script), set `skip_validation` to `true`.
 - **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
 
 `cluster` Configuration block for connection details about the target ADX cluster

--- a/docs/resources/adx_function.md
+++ b/docs/resources/adx_function.md
@@ -30,6 +30,7 @@ resource "adx_function" "test" {
 - **parameters** (String, Optional) Function parameters enclosed in parenthesis (myLimit:long)
 - **folder** (String, Optional) Name of the folder in which to place this entity
 - **docstring** (String, Optional) Free text describing the entity to be added. This string is presented in various UX settings next to the entity names.
+- **skipvalidation** (Bool, Optional) Determines whether or not to run validation logic on the function and fail the process if the function isn't valid. The default is `false`. *Note*: If a function involves cross-cluster queries and you plan to recreate the function using a [Kusto Query Language script](https://learn.microsoft.com/en-us/azure/data-explorer/database-script), set `skipvalidation` to `true`.
 - **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
 
 `cluster` Configuration block for connection details about the target ADX cluster

--- a/docs/resources/adx_table_continuous_export.md
+++ b/docs/resources/adx_table_continuous_export.md
@@ -1,0 +1,79 @@
+---
+page_title: "adx_table_continuous_export Resource - terraform-provider-adx"
+subcategory: ""
+description: |-
+  Manages an update policy for a table in ADX.
+---
+
+# Resource `adx_table_continuous_export`
+
+Manages an continuous export for a table in ADX.
+
+See: [ADX - Continuous Export ](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/data-export/continuous-data-export)
+
+## Example Usage
+
+```terraform
+
+resource "adx_table" "test_table" {
+  name            = "my_test_table"
+  database_name   = "my_db"
+  table_schema    = "name:string,color:string,number:int"
+  merge_on_update = false
+}
+
+
+resource "adx_external_table" "test_external_table" {
+    database_name               = "my_db"
+    name                        = "et_my_test_external_table"
+    data_format                 = "csv"
+    storage_connection_string   = "your_storage_SAS_url"
+    schema                      = "name:string,color:string,number:int"
+
+    depends_on = [ adx_table.test_table ]
+}
+
+
+resource "adx_table_continuous_export" "test_cont_export" {
+  database_name         = "my_db"
+  name                  = "ce_my_test_cont_export"
+  external_table_name   = "et_my_test_external_table"
+  query                  = "my_test_table"
+  interval_between_runs = "6m"
+
+  depends_on = [ adx_external_table.test_external_table ]
+}
+
+
+```
+
+## Argument Reference
+
+- **name** (String, Required) The name of the continuous export. Must be unique within the database.
+- **database_name** (String, Required) Database name within ADX that the target continuous export is in
+- **external_table_name** (String, Required) The name of the external table export target.
+- **query** (String, Required) The query to export.
+- **interval_between_runs** (String, Optional) The time span between continuous export executions. Must be greater than 1 minute. Default: 10h (10:00:00)
+- **forced_latency** (String, Optional) An optional period of time to limit the query to records that were ingested only prior to this period (relative to current time). This property is useful if, for example, the query performs some aggregations/joins and you would like to make sure all relevant records have already been ingested before running the export.
+- **size_limit** (Int, Optional) The size limit in bytes of a single storage artifact being written (prior to compression). Allowed range is 100 MB (default) to 1 GB.
+- **distributed** (Bool, Optional) Disable/enable distributed export. Setting to false is equivalent to single distribution hint. Default is true.
+- **parquet_row_group_size** (Int, Optional) Relevant only when data format is Parquet. Controls the row group size in the exported files. Default row group size is 100,000 records.
+- **use_native_parquet_writer** (Bool, Optional) Use the new export implementation when exporting to Parquet, this implementation is a more performant, resource light export mechanism. Note that an exported 'datetime' column is currently unsupported by Synapse SQL 'COPY'. Default is false.
+- **managed_identity** (String, Optional) The managed identity on behalf of which the continuous export job will run. The managed identity can be an object ID, or the system reserved word. For more information, see Use a managed identity to run a continuous export job.
+- **is_disabled** (Bool, Optional) Disable/enable the continuous export. Default is false.
+- **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
+
+`cluster` Configuration block for connection details about the target ADX cluster 
+
+*Note*: Any attributes specified here override the cluster config specified in the provider. Once a resource overrides an attribute specified in the provider, it will be stored explicitly as state for that resource and will not be possible to go back to the provider config unless explicitly unset.
+
+- **uri** - (String, Optional) Target ADX cluster endpoint URI, starting with `https://`
+- **client_id** - (String, Optional) The client ID for a service principal having admin access to this cluster/database.
+- **client_secret** - (String, Optional) The client secret for a service principal having admin access to this cluster/database
+- **tenant_id** - (String, Optional) Id for the tenant to which the service principal belongs
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- **id** - The ID of this resource.

--- a/docs/resources/adx_table_ingestion_time_policy.md
+++ b/docs/resources/adx_table_ingestion_time_policy.md
@@ -1,0 +1,43 @@
+---
+page_title: "adx_table_ingestion_time_policy Resource - terraform-provider-adx"
+subcategory: ""
+description: |-
+  Manages the ingestion time policy of a table in ADX.
+---
+
+# Resource `adx_table_ingestion_time_policy`
+
+Turns on or turns off a table's ingestion time policy. This policy adds a hidden datetime column in the table, called $IngestionTime. Whenever new data is ingested, the time of ingestion is recorded in the hidden column.
+
+See: [ADX - ingestion time Policy](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/ingestiontimepolicy)
+
+## Example Usage
+
+```terraform
+
+resource "adx_table" "test" {
+  name          = "Test1"
+  database_name = "test-db"
+  table_schema  = "f1:string,f2:string,f3:int"
+}
+
+resource "adx_table_ingestion_time_policy" "test" {
+  database_name      = "test-db"
+  table_name         = adx_table.test.name
+  enabled            = true
+}
+
+```
+
+## Argument Reference
+
+- **table_name** (String, Required) Name of the table containing the policy to modify
+- **database_name** (String, Required) Database name that the target table is in
+- **enabled** (Bool, Required) Determines whether to turn on or turn off the policy. true turns on the policy. false turns off the policy.
+
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- **id** - The ID of this resource.


### PR DESCRIPTION
## Description

This PR adds `skipvalidation` parameter support as specified in https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/create-function#supported-properties

closes #45 

## Tests

### terraform init

```
user-macOS:.test user$ terraform init

Initializing the backend...

Initializing provider plugins...
- Finding terraform.local/local/adx versions matching "0.0.1"...
- Installing terraform.local/local/adx v0.0.1...
- Installed terraform.local/local/adx v0.0.1 (unauthenticated)

Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

╷
│ Warning: Incomplete lock file information for providers
│ 
│ Due to your customized provider installation methods, Terraform was forced to calculate lock file checksums locally for the following providers:
│   - terraform.local/local/adx
│ 
│ The current .terraform.lock.hcl file only includes checksums for darwin_arm64, so Terraform running on another platform will fail to install these providers.
│ 
│ To calculate additional checksums for another platform, run:
│   terraform providers lock -platform=linux_amd64
│ (where linux_amd64 is the platform to generate)
╵

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
```

### terraform plan 1

```
user-macOS:.test user$ terraform plan

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # adx_function.test_skip_validation_false will be created
  + resource "adx_function" "test_skip_validation_false" {
      + body            = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT
      + database_name   = "TestDB"
      + folder          = "test"
      + id              = (known after apply)
      + name            = "test_skip_validation_false"
      + parameters      = "()"
      + skip_validation = false
    }

  # adx_function.test_skip_validation_not_set will be created
  + resource "adx_function" "test_skip_validation_not_set" {
      + body          = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT
      + database_name = "TestDB"
      + folder        = "test"
      + id            = (known after apply)
      + name          = "test_skip_validation_not_set"
      + parameters    = "()"
    }

  # adx_function.test_skip_validation_true will be created
  + resource "adx_function" "test_skip_validation_true" {
      + body            = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT
      + database_name   = "TestDB"
      + folder          = "test"
      + id              = (known after apply)
      + name            = "test_skip_validation_true"
      + parameters      = "()"
      + skip_validation = true
    }

Plan: 3 to add, 0 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```

### terraform apply

```
user-macOS:.test user$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # adx_function.test_skip_validation_false will be created
  + resource "adx_function" "test_skip_validation_false" {
      + body            = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT
      + database_name   = "TestDB"
      + folder          = "test"
      + id              = (known after apply)
      + name            = "test_skip_validation_false"
      + parameters      = "()"
      + skip_validation = false
    }

  # adx_function.test_skip_validation_not_set will be created
  + resource "adx_function" "test_skip_validation_not_set" {
      + body          = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT
      + database_name = "TestDB"
      + folder        = "test"
      + id            = (known after apply)
      + name          = "test_skip_validation_not_set"
      + parameters    = "()"
    }

  # adx_function.test_skip_validation_true will be created
  + resource "adx_function" "test_skip_validation_true" {
      + body            = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT
      + database_name   = "TestDB"
      + folder          = "test"
      + id              = (known after apply)
      + name            = "test_skip_validation_true"
      + parameters      = "()"
      + skip_validation = true
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

adx_function.test_skip_validation_true: Creating...
adx_function.test_skip_validation_false: Creating...
adx_function.test_skip_validation_not_set: Creating...
adx_function.test_skip_validation_true: Creation complete after 1s [id=azeu2testcluster.eastus2.kusto.windows.net|TestDB|function|test_skip_validation_true]
╷
│ Error: error creating function test_skip_validation_not_set (Database "TestDB"): Op(OpMgmt): Kind(KHTTPError): error from Kusto endpoint for query ".create function with(folder='test', skipvalidation=false)\ntest_skip_validation_not_set()\n{union\n    (cluster(\"https://azeu2cluster.eastus2.kusto.windows.net\").database(\"Database\").table(\"Table\")\n    | extend Region_s = \"eastus2\"),\n    (cluster(\"https://azeucluster.eastus.kusto.windows.net\").database(\"Database\").table(\"Table\")\n    | extend Region_s = \"eastus\")\n}": (400 BadRequest):
│ {
│     "error": {
│         "code": "General_BadRequest",
│         "message": "Request is invalid and cannot be executed.",
│         "@type": "Kusto.Data.Exceptions.KustoBadRequestException",
│         "@message": "Request is invalid and cannot be processed: Semantic error: SEM0056: Errors occurred while resolving remote entities. Cluster='https://azeu2cluster.eastus2.kusto.windows.net/': The remote cluster is not allowed by the callout policy",
│         "@context": {
│             "timestamp": "2024-01-15T13:10:24.9284874Z",
│             "serviceAlias": "azeu2testcluster",
│             "machineName": "KSENGINE000001",
│             "processName": "Kusto.WinSvc.Svc",
│             "processId": 3808,
│             "threadId": 14464,
│             "clientRequestId": "KGC.execute;00000000-0000-0000-0000-6da7db3803bc",
│             "activityId": "00000000-0000-0000-0000-74da83c22b42",
│             "subActivityId": "00000000-0000-0000-0000-61253d428292",
│             "activityType": "DN.AdminCommand.FunctionCreateCommand",
│             "parentActivityId": "00000000-0000-0000-0000-a7b9ab6a2edb",
│             "activityStack": "(Activity stack: CRID=KGC.execute;00000000-0000-0000-0000-6da7db3803bc ARID=00000000-0000-0000-0000-74da83c22b42 > DN.Admin.Client.ExecuteControlCommand/00000000-0000-0000-0000-49ff63cb7e74 > P.WCF.Service.ExecuteControlCommand..IInterNodeCommunicationAdminContract/00000000-0000-0000-0000-ca727b137452 > DN.FE.ExecuteControlCommand/00000000-0000-0000-0000-a7b9ab6a2edb > DN.AdminCommand.FunctionCreateCommand/00000000-0000-0000-0000-61253d428292)"
│         },
│         "@permanent": true,
│         "@text": "{union\n    (cluster(\"https://azeu2cluster.eastus2.kusto.windows.net\").database(\"Database\").table(\"Table\")\n    | extend Region_s = \"eastus2\"),\n    (cluster(\"https://azeucluster.eastus.kusto.windows.net\").database(\"Database\").table(\"Table\")\n    | extend Region_s = \"eastus\")\n}",
│         "@database": "TestDB",
│         "innererror": {
│             "code": "SEM0056",
│             "message": "Errors occurred while resolving remote entities. Cluster='https://azeu2cluster.eastus2.kusto.windows.net/': The remote cluster is not allowed by the callout policy",
│             "@type": "Kusto.Data.Exceptions.SemanticException",
│             "@message": "Semantic error: SEM0056: Errors occurred while resolving remote entities. Cluster='https://azeu2cluster.eastus2.kusto.windows.net/': The remote cluster is not allowed by the callout policy",
│             "@context": {
│                 "timestamp": "2024-01-15T13:10:24.9284874Z",
│                 "serviceAlias": "azeu2testcluster",
│                 "machineName": "KSENGINE000001",
│                 "processName": "Kusto.WinSvc.Svc",
│                 "processId": 3808,
│                 "threadId": 14464,
│                 "clientRequestId": "KGC.execute;00000000-0000-0000-0000-6da7db3803bc",
│                 "activityId": "00000000-0000-0000-0000-74da83c22b42",
│                 "subActivityId": "00000000-0000-0000-0000-61253d428292",
│                 "activityType": "DN.AdminCommand.FunctionCreateCommand",
│                 "parentActivityId": "00000000-0000-0000-0000-a7b9ab6a2edb",
│                 "activityStack": "(Activity stack: CRID=KGC.execute;00000000-0000-0000-0000-6da7db3803bc ARID=00000000-0000-0000-0000-74da83c22b42 > DN.Admin.Client.ExecuteControlCommand/00000000-0000-0000-0000-49ff63cb7e74 > P.WCF.Service.ExecuteControlCommand..IInterNodeCommunicationAdminContract/00000000-0000-0000-0000-ca727b137452 > DN.FE.ExecuteControlCommand/00000000-0000-0000-0000-a7b9ab6a2edb > DN.AdminCommand.FunctionCreateCommand/00000000-0000-0000-0000-61253d428292)"
│             },
│             "@permanent": true,
│             "@errorCode": "SEM0056",
│             "@errorMessage": "Errors occurred while resolving remote entities. Cluster='https://azeu2cluster.eastus2.kusto.windows.net/': The remote cluster is not allowed by the callout policy"
│         }
│     }
│ }
│ 
│   with adx_function.test_skip_validation_not_set,
│   on main.tf line 29, in resource "adx_function" "test_skip_validation_not_set":
│   29: resource "adx_function" "test_skip_validation_not_set" {
│ 
╵
╷
│ Error: error creating function test_skip_validation_false (Database "TestDB"): Op(OpMgmt): Kind(KHTTPError): error from Kusto endpoint for query ".create function with(folder='test', skipvalidation=false)\ntest_skip_validation_false()\n{union\n    (cluster(\"https://azeu2cluster.eastus2.kusto.windows.net\").database(\"Database\").table(\"Table\")\n    | extend Region_s = \"eastus2\"),\n    (cluster(\"https://azeucluster.eastus.kusto.windows.net\").database(\"Database\").table(\"Table\")\n    | extend Region_s = \"eastus\")\n}": (400 BadRequest):
│ {
│     "error": {
│         "code": "General_BadRequest",
│         "message": "Request is invalid and cannot be executed.",
│         "@type": "Kusto.Data.Exceptions.KustoBadRequestException",
│         "@message": "Request is invalid and cannot be processed: Semantic error: SEM0056: Errors occurred while resolving remote entities. Cluster='https://azeu2cluster.eastus2.kusto.windows.net/': The remote cluster is not allowed by the callout policy",
│         "@context": {
│             "timestamp": "2024-01-15T13:10:25.0534863Z",
│             "serviceAlias": "azeu2testcluster",
│             "machineName": "KSENGINE000001",
│             "processName": "Kusto.WinSvc.Svc",
│             "processId": 3808,
│             "threadId": 14464,
│             "clientRequestId": "KGC.execute;00000000-0000-0000-0000-9104b7a38d7e",
│             "activityId": "00000000-0000-0000-0000-9a8eb4dad855",
│             "subActivityId": "00000000-0000-0000-0000-49389a0ba2c1",
│             "activityType": "DN.AdminCommand.FunctionCreateCommand",
│             "parentActivityId": "00000000-0000-0000-0000-db57b6ed953f",
│             "activityStack": "(Activity stack: CRID=KGC.execute;00000000-0000-0000-0000-9104b7a38d7e ARID=00000000-0000-0000-0000-9a8eb4dad855 > DN.Admin.Client.ExecuteControlCommand/00000000-0000-0000-0000-fafa4cf8fa2d > P.WCF.Service.ExecuteControlCommand..IInterNodeCommunicationAdminContract/00000000-0000-0000-0000-d76a2e2df8b6 > DN.FE.ExecuteControlCommand/00000000-0000-0000-0000-db57b6ed953f > DN.AdminCommand.FunctionCreateCommand/00000000-0000-0000-0000-49389a0ba2c1)"
│         },
│         "@permanent": true,
│         "@text": "{union\n    (cluster(\"https://azeu2cluster.eastus2.kusto.windows.net\").database(\"Database\").table(\"Table\")\n    | extend Region_s = \"eastus2\"),\n    (cluster(\"https://azeucluster.eastus.kusto.windows.net\").database(\"Database\").table(\"Table\")\n    | extend Region_s = \"eastus\")\n}",
│         "@database": "TestDB",
│         "innererror": {
│             "code": "SEM0056",
│             "message": "Errors occurred while resolving remote entities. Cluster='https://azeu2cluster.eastus2.kusto.windows.net/': The remote cluster is not allowed by the callout policy",
│             "@type": "Kusto.Data.Exceptions.SemanticException",
│             "@message": "Semantic error: SEM0056: Errors occurred while resolving remote entities. Cluster='https://azeu2cluster.eastus2.kusto.windows.net/': The remote cluster is not allowed by the callout policy",
│             "@context": {
│                 "timestamp": "2024-01-15T13:10:25.0534863Z",
│                 "serviceAlias": "azeu2testcluster",
│                 "machineName": "KSENGINE000001",
│                 "processName": "Kusto.WinSvc.Svc",
│                 "processId": 3808,
│                 "threadId": 14464,
│                 "clientRequestId": "KGC.execute;00000000-0000-0000-0000-9104b7a38d7e",
│                 "activityId": "00000000-0000-0000-0000-9a8eb4dad855",
│                 "subActivityId": "00000000-0000-0000-0000-49389a0ba2c1",
│                 "activityType": "DN.AdminCommand.FunctionCreateCommand",
│                 "parentActivityId": "00000000-0000-0000-0000-db57b6ed953f",
│                 "activityStack": "(Activity stack: CRID=KGC.execute;00000000-0000-0000-0000-9104b7a38d7e ARID=00000000-0000-0000-0000-9a8eb4dad855 > DN.Admin.Client.ExecuteControlCommand/00000000-0000-0000-0000-fafa4cf8fa2d > P.WCF.Service.ExecuteControlCommand..IInterNodeCommunicationAdminContract/00000000-0000-0000-0000-d76a2e2df8b6 > DN.FE.ExecuteControlCommand/00000000-0000-0000-0000-db57b6ed953f > DN.AdminCommand.FunctionCreateCommand/00000000-0000-0000-0000-49389a0ba2c1)"
│             },
│             "@permanent": true,
│             "@errorCode": "SEM0056",
│             "@errorMessage": "Errors occurred while resolving remote entities. Cluster='https://azeu2cluster.eastus2.kusto.windows.net/': The remote cluster is not allowed by the callout policy"
│         }
│     }
│ }
│ 
│   with adx_function.test_skip_validation_false,
│   on main.tf line 36, in resource "adx_function" "test_skip_validation_false":
│   36: resource "adx_function" "test_skip_validation_false" {
│ 
╵
```

Confirming after apply:

![image](https://github.com/favoretti/terraform-provider-adx/assets/10341068/873b6fc2-c254-4037-ade1-1471297e323f)

### terraform plan 2

```
user-macOS:.test user$ terraform plan
adx_function.test_skip_validation_true: Refreshing state... [id=azeu2testcluster.eastus2.kusto.windows.net|TestDB|function|test_skip_validation_true]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # adx_function.test_skip_validation_false will be created
  + resource "adx_function" "test_skip_validation_false" {
      + body            = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT
      + database_name   = "TestDB"
      + folder          = "test"
      + id              = (known after apply)
      + name            = "test_skip_validation_false"
      + parameters      = "()"
      + skip_validation = false
    }

  # adx_function.test_skip_validation_not_set will be created
  + resource "adx_function" "test_skip_validation_not_set" {
      + body          = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT
      + database_name = "TestDB"
      + folder        = "test"
      + id            = (known after apply)
      + name          = "test_skip_validation_not_set"
      + parameters    = "()"
    }

Plan: 2 to add, 0 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```

### terraform destroy

```
user-macOS:.test user$ terraform destroy
adx_function.test_skip_validation_true: Refreshing state... [id=azeu2testcluster.eastus2.kusto.windows.net|TestDB|function|test_skip_validation_true]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # adx_function.test_skip_validation_true will be destroyed
  - resource "adx_function" "test_skip_validation_true" {
      - body            = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT -> null
      - database_name   = "TestDB" -> null
      - folder          = "test" -> null
      - id              = "azeu2testcluster.eastus2.kusto.windows.net|TestDB|function|test_skip_validation_true" -> null
      - name            = "test_skip_validation_true" -> null
      - parameters      = "()" -> null
      - skip_validation = true -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

adx_function.test_skip_validation_true: Destroying... [id=azeu2testcluster.eastus2.kusto.windows.net|TestDB|function|test_skip_validation_true]
adx_function.test_skip_validation_true: Destruction complete after 1s

Destroy complete! Resources: 1 destroyed.
```
