### PR TITLE
Add skip_validation parameter to adx_function resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v0.0.32
 
-* Fixed #45. Add `skipvalidation` parameter to `adx_function` resource
+* Fixed #45. Add `skip_validation` parameter to `adx_function` resource
 
 ## v0.0.31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.32
+
+* Fixed #45. Add `skipvalidation` parameter to `adx_function` resource
+
 ## v0.0.31
 
 * Bugfix: add `adx_table_ingestion_time_policy` to provider init

--- a/adx/resource_adx_function.go
+++ b/adx/resource_adx_function.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"strconv"
 
 	"github.com/Azure/azure-kusto-go/kusto"
 	"github.com/Azure/azure-kusto-go/kusto/unsafe"
@@ -16,11 +17,12 @@ import (
 )
 
 type ADXFunction struct {
-	Name       string
-	Parameters string
-	Body       string
-	Folder     string
-	DocString  string
+	Name           string
+	Parameters     string
+	Body           string
+	Folder         string
+	DocString      string
+	SkipValidation bool
 }
 
 func resourceADXFunction() *schema.Resource {
@@ -76,6 +78,11 @@ func resourceADXFunction() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
+			"skip_validation": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 		CustomizeDiff: clusterConfigCustomDiff,
 	}
@@ -107,6 +114,9 @@ func resourceADXFunctionCreateUpdate(ctx context.Context, d *schema.ResourceData
 	}
 	if folder, ok := d.GetOk("folder"); ok {
 		withParams = append(withParams, fmt.Sprintf("folder='%s'", folder))
+	}
+	if skip_validation, ok := d.Get("skip_validation").(bool); ok {
+		withParams = append(withParams, fmt.Sprintf("skipvalidation=%s", strconv.FormatBool(skip_validation)))
 	}
 
 	withClause := ""

--- a/docs/resources/adx_function.md
+++ b/docs/resources/adx_function.md
@@ -30,6 +30,7 @@ resource "adx_function" "test" {
 - **parameters** (String, Optional) Function parameters enclosed in parenthesis (myLimit:long)
 - **folder** (String, Optional) Name of the folder in which to place this entity
 - **docstring** (String, Optional) Free text describing the entity to be added. This string is presented in various UX settings next to the entity names.
+- **skip_validation** (Bool, Optional) Determines whether or not to run validation logic on the function and fail the process if the function isn't valid. The default is `false`. *Note*: If a function involves cross-cluster queries and you plan to recreate the function using a [Kusto Query Language script](https://learn.microsoft.com/en-us/azure/data-explorer/database-script), set `skip_validation` to `true`.
 - **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
 
 `cluster` Configuration block for connection details about the target ADX cluster


### PR DESCRIPTION
## Description

This PR adds `skip_validation` parameter to `adx_function` resource as specified in https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/create-function#supported-properties

closes #45

## Tests

### main.tf

```
terraform {
  required_providers {
    # Third party provider for ADX cluster tables and schema creation and management
    adx = {
      source  = "terraform.local/local/adx"
      version = "0.0.1"
    }
  }
  required_version = ">= 0.15.01"
}

provider "adx" {
  adx_endpoint  = "https://azeu2testcluster.eastus2.kusto.windows.net"
  client_id     = "xxx"
  client_secret = "xxx"
  tenant_id     = "xxx"
}

locals {
  function_body = <<-STR
    union
        (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
        | extend Region_s = "eastus2"),
        (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
        | extend Region_s = "eastus")
    STR
}

resource "adx_function" "test_skip_validation_not_set" {
  name          = "test_skip_validation_not_set"
  body          = "{${local.function_body}}"
  folder        = "test"
  database_name = "TestDB"
}

resource "adx_function" "test_skip_validation_false" {
  name            = "test_skip_validation_false"
  body            = "{${local.function_body}}"
  folder          = "test"
  database_name   = "TestDB"
  skip_validation = false
}

resource "adx_function" "test_skip_validation_true" {
  name            = "test_skip_validation_true"
  body            = "{${local.function_body}}"
  folder          = "test"
  database_name   = "TestDB"
  skip_validation = true
}
```

### terraform init

```
user-macOS:.test user$ terraform init

Initializing the backend...

Initializing provider plugins...
- Finding terraform.local/local/adx versions matching "0.0.1"...
- Installing terraform.local/local/adx v0.0.1...
- Installed terraform.local/local/adx v0.0.1 (unauthenticated)

Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

╷
│ Warning: Incomplete lock file information for providers
│ 
│ Due to your customized provider installation methods, Terraform was forced to calculate lock file checksums locally for the following providers:
│   - terraform.local/local/adx
│ 
│ The current .terraform.lock.hcl file only includes checksums for darwin_arm64, so Terraform running on another platform will fail to install these providers.
│ 
│ To calculate additional checksums for another platform, run:
│   terraform providers lock -platform=linux_amd64
│ (where linux_amd64 is the platform to generate)
╵

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
```

### terraform plan 1

```
user-macOS:.test user$ terraform plan

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # adx_function.test_skip_validation_false will be created
  + resource "adx_function" "test_skip_validation_false" {
      + body            = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT
      + database_name   = "TestDB"
      + folder          = "test"
      + id              = (known after apply)
      + name            = "test_skip_validation_false"
      + parameters      = "()"
      + skip_validation = false
    }

  # adx_function.test_skip_validation_not_set will be created
  + resource "adx_function" "test_skip_validation_not_set" {
      + body          = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT
      + database_name = "TestDB"
      + folder        = "test"
      + id            = (known after apply)
      + name          = "test_skip_validation_not_set"
      + parameters    = "()"
    }

  # adx_function.test_skip_validation_true will be created
  + resource "adx_function" "test_skip_validation_true" {
      + body            = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT
      + database_name   = "TestDB"
      + folder          = "test"
      + id              = (known after apply)
      + name            = "test_skip_validation_true"
      + parameters      = "()"
      + skip_validation = true
    }

Plan: 3 to add, 0 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```

### terraform apply

```
user-macOS:.test user$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # adx_function.test_skip_validation_false will be created
  + resource "adx_function" "test_skip_validation_false" {
      + body            = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT
      + database_name   = "TestDB"
      + folder          = "test"
      + id              = (known after apply)
      + name            = "test_skip_validation_false"
      + parameters      = "()"
      + skip_validation = false
    }

  # adx_function.test_skip_validation_not_set will be created
  + resource "adx_function" "test_skip_validation_not_set" {
      + body          = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT
      + database_name = "TestDB"
      + folder        = "test"
      + id            = (known after apply)
      + name          = "test_skip_validation_not_set"
      + parameters    = "()"
    }

  # adx_function.test_skip_validation_true will be created
  + resource "adx_function" "test_skip_validation_true" {
      + body            = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT
      + database_name   = "TestDB"
      + folder          = "test"
      + id              = (known after apply)
      + name            = "test_skip_validation_true"
      + parameters      = "()"
      + skip_validation = true
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

adx_function.test_skip_validation_true: Creating...
adx_function.test_skip_validation_false: Creating...
adx_function.test_skip_validation_not_set: Creating...
adx_function.test_skip_validation_true: Creation complete after 1s [id=azeu2testcluster.eastus2.kusto.windows.net|TestDB|function|test_skip_validation_true]
╷
│ Error: error creating function test_skip_validation_not_set (Database "TestDB"): Op(OpMgmt): Kind(KHTTPError): error from Kusto endpoint for query ".create function with(folder='test', skipvalidation=false)\ntest_skip_validation_not_set()\n{union\n    (cluster(\"https://azeu2cluster.eastus2.kusto.windows.net\").database(\"Database\").table(\"Table\")\n    | extend Region_s = \"eastus2\"),\n    (cluster(\"https://azeucluster.eastus.kusto.windows.net\").database(\"Database\").table(\"Table\")\n    | extend Region_s = \"eastus\")\n}": (400 BadRequest):
│ {
│     "error": {
│         "code": "General_BadRequest",
│         "message": "Request is invalid and cannot be executed.",
│         "@type": "Kusto.Data.Exceptions.KustoBadRequestException",
│         "@message": "Request is invalid and cannot be processed: Semantic error: SEM0056: Errors occurred while resolving remote entities. Cluster='https://azeu2cluster.eastus2.kusto.windows.net/': The remote cluster is not allowed by the callout policy",
│         "@context": {
│             "timestamp": "2024-01-15T13:10:24.9284874Z",
│             "serviceAlias": "azeu2testcluster",
│             "machineName": "KSENGINE000001",
│             "processName": "Kusto.WinSvc.Svc",
│             "processId": 3808,
│             "threadId": 14464,
│             "clientRequestId": "KGC.execute;00000000-0000-0000-0000-6da7db3803bc",
│             "activityId": "00000000-0000-0000-0000-74da83c22b42",
│             "subActivityId": "00000000-0000-0000-0000-61253d428292",
│             "activityType": "DN.AdminCommand.FunctionCreateCommand",
│             "parentActivityId": "00000000-0000-0000-0000-a7b9ab6a2edb",
│             "activityStack": "(Activity stack: CRID=KGC.execute;00000000-0000-0000-0000-6da7db3803bc ARID=00000000-0000-0000-0000-74da83c22b42 > DN.Admin.Client.ExecuteControlCommand/00000000-0000-0000-0000-49ff63cb7e74 > P.WCF.Service.ExecuteControlCommand..IInterNodeCommunicationAdminContract/00000000-0000-0000-0000-ca727b137452 > DN.FE.ExecuteControlCommand/00000000-0000-0000-0000-a7b9ab6a2edb > DN.AdminCommand.FunctionCreateCommand/00000000-0000-0000-0000-61253d428292)"
│         },
│         "@permanent": true,
│         "@text": "{union\n    (cluster(\"https://azeu2cluster.eastus2.kusto.windows.net\").database(\"Database\").table(\"Table\")\n    | extend Region_s = \"eastus2\"),\n    (cluster(\"https://azeucluster.eastus.kusto.windows.net\").database(\"Database\").table(\"Table\")\n    | extend Region_s = \"eastus\")\n}",
│         "@database": "TestDB",
│         "innererror": {
│             "code": "SEM0056",
│             "message": "Errors occurred while resolving remote entities. Cluster='https://azeu2cluster.eastus2.kusto.windows.net/': The remote cluster is not allowed by the callout policy",
│             "@type": "Kusto.Data.Exceptions.SemanticException",
│             "@message": "Semantic error: SEM0056: Errors occurred while resolving remote entities. Cluster='https://azeu2cluster.eastus2.kusto.windows.net/': The remote cluster is not allowed by the callout policy",
│             "@context": {
│                 "timestamp": "2024-01-15T13:10:24.9284874Z",
│                 "serviceAlias": "azeu2testcluster",
│                 "machineName": "KSENGINE000001",
│                 "processName": "Kusto.WinSvc.Svc",
│                 "processId": 3808,
│                 "threadId": 14464,
│                 "clientRequestId": "KGC.execute;00000000-0000-0000-0000-6da7db3803bc",
│                 "activityId": "00000000-0000-0000-0000-74da83c22b42",
│                 "subActivityId": "00000000-0000-0000-0000-61253d428292",
│                 "activityType": "DN.AdminCommand.FunctionCreateCommand",
│                 "parentActivityId": "00000000-0000-0000-0000-a7b9ab6a2edb",
│                 "activityStack": "(Activity stack: CRID=KGC.execute;00000000-0000-0000-0000-6da7db3803bc ARID=00000000-0000-0000-0000-74da83c22b42 > DN.Admin.Client.ExecuteControlCommand/00000000-0000-0000-0000-49ff63cb7e74 > P.WCF.Service.ExecuteControlCommand..IInterNodeCommunicationAdminContract/00000000-0000-0000-0000-ca727b137452 > DN.FE.ExecuteControlCommand/00000000-0000-0000-0000-a7b9ab6a2edb > DN.AdminCommand.FunctionCreateCommand/00000000-0000-0000-0000-61253d428292)"
│             },
│             "@permanent": true,
│             "@errorCode": "SEM0056",
│             "@errorMessage": "Errors occurred while resolving remote entities. Cluster='https://azeu2cluster.eastus2.kusto.windows.net/': The remote cluster is not allowed by the callout policy"
│         }
│     }
│ }
│ 
│   with adx_function.test_skip_validation_not_set,
│   on main.tf line 29, in resource "adx_function" "test_skip_validation_not_set":
│   29: resource "adx_function" "test_skip_validation_not_set" {
│ 
╵
╷
│ Error: error creating function test_skip_validation_false (Database "TestDB"): Op(OpMgmt): Kind(KHTTPError): error from Kusto endpoint for query ".create function with(folder='test', skipvalidation=false)\ntest_skip_validation_false()\n{union\n    (cluster(\"https://azeu2cluster.eastus2.kusto.windows.net\").database(\"Database\").table(\"Table\")\n    | extend Region_s = \"eastus2\"),\n    (cluster(\"https://azeucluster.eastus.kusto.windows.net\").database(\"Database\").table(\"Table\")\n    | extend Region_s = \"eastus\")\n}": (400 BadRequest):
│ {
│     "error": {
│         "code": "General_BadRequest",
│         "message": "Request is invalid and cannot be executed.",
│         "@type": "Kusto.Data.Exceptions.KustoBadRequestException",
│         "@message": "Request is invalid and cannot be processed: Semantic error: SEM0056: Errors occurred while resolving remote entities. Cluster='https://azeu2cluster.eastus2.kusto.windows.net/': The remote cluster is not allowed by the callout policy",
│         "@context": {
│             "timestamp": "2024-01-15T13:10:25.0534863Z",
│             "serviceAlias": "azeu2testcluster",
│             "machineName": "KSENGINE000001",
│             "processName": "Kusto.WinSvc.Svc",
│             "processId": 3808,
│             "threadId": 14464,
│             "clientRequestId": "KGC.execute;00000000-0000-0000-0000-9104b7a38d7e",
│             "activityId": "00000000-0000-0000-0000-9a8eb4dad855",
│             "subActivityId": "00000000-0000-0000-0000-49389a0ba2c1",
│             "activityType": "DN.AdminCommand.FunctionCreateCommand",
│             "parentActivityId": "00000000-0000-0000-0000-db57b6ed953f",
│             "activityStack": "(Activity stack: CRID=KGC.execute;00000000-0000-0000-0000-9104b7a38d7e ARID=00000000-0000-0000-0000-9a8eb4dad855 > DN.Admin.Client.ExecuteControlCommand/00000000-0000-0000-0000-fafa4cf8fa2d > P.WCF.Service.ExecuteControlCommand..IInterNodeCommunicationAdminContract/00000000-0000-0000-0000-d76a2e2df8b6 > DN.FE.ExecuteControlCommand/00000000-0000-0000-0000-db57b6ed953f > DN.AdminCommand.FunctionCreateCommand/00000000-0000-0000-0000-49389a0ba2c1)"
│         },
│         "@permanent": true,
│         "@text": "{union\n    (cluster(\"https://azeu2cluster.eastus2.kusto.windows.net\").database(\"Database\").table(\"Table\")\n    | extend Region_s = \"eastus2\"),\n    (cluster(\"https://azeucluster.eastus.kusto.windows.net\").database(\"Database\").table(\"Table\")\n    | extend Region_s = \"eastus\")\n}",
│         "@database": "TestDB",
│         "innererror": {
│             "code": "SEM0056",
│             "message": "Errors occurred while resolving remote entities. Cluster='https://azeu2cluster.eastus2.kusto.windows.net/': The remote cluster is not allowed by the callout policy",
│             "@type": "Kusto.Data.Exceptions.SemanticException",
│             "@message": "Semantic error: SEM0056: Errors occurred while resolving remote entities. Cluster='https://azeu2cluster.eastus2.kusto.windows.net/': The remote cluster is not allowed by the callout policy",
│             "@context": {
│                 "timestamp": "2024-01-15T13:10:25.0534863Z",
│                 "serviceAlias": "azeu2testcluster",
│                 "machineName": "KSENGINE000001",
│                 "processName": "Kusto.WinSvc.Svc",
│                 "processId": 3808,
│                 "threadId": 14464,
│                 "clientRequestId": "KGC.execute;00000000-0000-0000-0000-9104b7a38d7e",
│                 "activityId": "00000000-0000-0000-0000-9a8eb4dad855",
│                 "subActivityId": "00000000-0000-0000-0000-49389a0ba2c1",
│                 "activityType": "DN.AdminCommand.FunctionCreateCommand",
│                 "parentActivityId": "00000000-0000-0000-0000-db57b6ed953f",
│                 "activityStack": "(Activity stack: CRID=KGC.execute;00000000-0000-0000-0000-9104b7a38d7e ARID=00000000-0000-0000-0000-9a8eb4dad855 > DN.Admin.Client.ExecuteControlCommand/00000000-0000-0000-0000-fafa4cf8fa2d > P.WCF.Service.ExecuteControlCommand..IInterNodeCommunicationAdminContract/00000000-0000-0000-0000-d76a2e2df8b6 > DN.FE.ExecuteControlCommand/00000000-0000-0000-0000-db57b6ed953f > DN.AdminCommand.FunctionCreateCommand/00000000-0000-0000-0000-49389a0ba2c1)"
│             },
│             "@permanent": true,
│             "@errorCode": "SEM0056",
│             "@errorMessage": "Errors occurred while resolving remote entities. Cluster='https://azeu2cluster.eastus2.kusto.windows.net/': The remote cluster is not allowed by the callout policy"
│         }
│     }
│ }
│ 
│   with adx_function.test_skip_validation_false,
│   on main.tf line 36, in resource "adx_function" "test_skip_validation_false":
│   36: resource "adx_function" "test_skip_validation_false" {
│ 
╵
```

Confirming after apply:

![image](https://github.com/favoretti/terraform-provider-adx/assets/10341068/873b6fc2-c254-4037-ade1-1471297e323f)

### terraform plan 2

```
user-macOS:.test user$ terraform plan
adx_function.test_skip_validation_true: Refreshing state... [id=azeu2testcluster.eastus2.kusto.windows.net|TestDB|function|test_skip_validation_true]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # adx_function.test_skip_validation_false will be created
  + resource "adx_function" "test_skip_validation_false" {
      + body            = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT
      + database_name   = "TestDB"
      + folder          = "test"
      + id              = (known after apply)
      + name            = "test_skip_validation_false"
      + parameters      = "()"
      + skip_validation = false
    }

  # adx_function.test_skip_validation_not_set will be created
  + resource "adx_function" "test_skip_validation_not_set" {
      + body          = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT
      + database_name = "TestDB"
      + folder        = "test"
      + id            = (known after apply)
      + name          = "test_skip_validation_not_set"
      + parameters    = "()"
    }

Plan: 2 to add, 0 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```

### terraform destroy

```
user-macOS:.test user$ terraform destroy
adx_function.test_skip_validation_true: Refreshing state... [id=azeu2testcluster.eastus2.kusto.windows.net|TestDB|function|test_skip_validation_true]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # adx_function.test_skip_validation_true will be destroyed
  - resource "adx_function" "test_skip_validation_true" {
      - body            = <<-EOT
            {union
                (cluster("https://azeu2cluster.eastus2.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus2"),
                (cluster("https://azeucluster.eastus.kusto.windows.net").database("Database").table("Table")
                | extend Region_s = "eastus")
            }
        EOT -> null
      - database_name   = "TestDB" -> null
      - folder          = "test" -> null
      - id              = "azeu2testcluster.eastus2.kusto.windows.net|TestDB|function|test_skip_validation_true" -> null
      - name            = "test_skip_validation_true" -> null
      - parameters      = "()" -> null
      - skip_validation = true -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

adx_function.test_skip_validation_true: Destroying... [id=azeu2testcluster.eastus2.kusto.windows.net|TestDB|function|test_skip_validation_true]
adx_function.test_skip_validation_true: Destruction complete after 1s

Destroy complete! Resources: 1 destroyed.
```
