### PR TITLE
Add Managed Identity as argument to Update Policy

### DIFF
--- a/adx/resource_adx_table_update_policy.go
+++ b/adx/resource_adx_table_update_policy.go
@@ -17,6 +17,7 @@ type TableUpdatePolicy struct {
 	Query                        string
 	IsTransactional              bool
 	PropagateIngestionProperties bool
+	ManagedIdentity              string
 }
 
 func resourceADXTableUpdatePolicy() *schema.Resource {
@@ -73,6 +74,12 @@ func resourceADXTableUpdatePolicy() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+
+			"managed_identity": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validate.StringIsSystemOrUUID,
+			},
 		},
 		CustomizeDiff: clusterConfigCustomDiff,
 	}
@@ -87,7 +94,13 @@ func resourceADXTableUpdatePolicyCreateUpdate(ctx context.Context, d *schema.Res
 	transactional := d.Get("transactional").(bool)
 	propagateIngestionProperties := d.Get("propagate_ingestion_properties").(bool)
 
-	createStatement := fmt.Sprintf(".alter table %s policy update @'[{\"IsEnabled\": %t, \"Source\": \"%s\", \"Query\": \"%s\", \"IsTransactional\": %t, \"PropagateIngestionProperties\": %t}]'", tableName, enabled, sourceTable, query, transactional, propagateIngestionProperties)
+	var createStatement string
+	if len(d.Get("managed_identity").(string)) > 0 {
+		managedIdentity := d.Get("managed_identity").(string)
+		createStatement = fmt.Sprintf(".alter table %s policy update @'[{\"IsEnabled\": %t, \"Source\": \"%s\", \"Query\": \"%s\", \"IsTransactional\": %t, \"PropagateIngestionProperties\": %t, \"ManagedIdentity\": \"%s\"}]'", tableName, enabled, sourceTable, query, transactional, propagateIngestionProperties, managedIdentity)
+	} else {
+		createStatement = fmt.Sprintf(".alter table %s policy update @'[{\"IsEnabled\": %t, \"Source\": \"%s\", \"Query\": \"%s\", \"IsTransactional\": %t, \"PropagateIngestionProperties\": %t}]'", tableName, enabled, sourceTable, query, transactional, propagateIngestionProperties)
+	}
 
 	if err := createADXPolicy(ctx, d, meta, "table", "update", databaseName, tableName, createStatement); err != nil {
 		return diag.Errorf("%+v", err)
@@ -114,6 +127,7 @@ func resourceADXTableUpdatePolicyRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("query", policy[0].Query)
 	d.Set("transactional", policy[0].IsTransactional)
 	d.Set("propagate_ingestion_properties", policy[0].PropagateIngestionProperties)
+	d.Set("managed_identity", policy[0].ManagedIdentity)
 
 	return diags
 }

--- a/adx/resource_adx_table_update_policy.go
+++ b/adx/resource_adx_table_update_policy.go
@@ -94,12 +94,11 @@ func resourceADXTableUpdatePolicyCreateUpdate(ctx context.Context, d *schema.Res
 	transactional := d.Get("transactional").(bool)
 	propagateIngestionProperties := d.Get("propagate_ingestion_properties").(bool)
 
-	var createStatement string
+	createStatement := fmt.Sprintf(".alter table %s policy update @'[{\"IsEnabled\": %t, \"Source\": \"%s\", \"Query\": \"%s\", \"IsTransactional\": %t, \"PropagateIngestionProperties\": %t}]'", tableName, enabled, sourceTable, query, transactional, propagateIngestionProperties)
+	
 	if len(d.Get("managed_identity").(string)) > 0 {
 		managedIdentity := d.Get("managed_identity").(string)
 		createStatement = fmt.Sprintf(".alter table %s policy update @'[{\"IsEnabled\": %t, \"Source\": \"%s\", \"Query\": \"%s\", \"IsTransactional\": %t, \"PropagateIngestionProperties\": %t, \"ManagedIdentity\": \"%s\"}]'", tableName, enabled, sourceTable, query, transactional, propagateIngestionProperties, managedIdentity)
-	} else {
-		createStatement = fmt.Sprintf(".alter table %s policy update @'[{\"IsEnabled\": %t, \"Source\": \"%s\", \"Query\": \"%s\", \"IsTransactional\": %t, \"PropagateIngestionProperties\": %t}]'", tableName, enabled, sourceTable, query, transactional, propagateIngestionProperties)
 	}
 
 	if err := createADXPolicy(ctx, d, meta, "table", "update", databaseName, tableName, createStatement); err != nil {

--- a/adx/validate/validate.go
+++ b/adx/validate/validate.go
@@ -84,3 +84,20 @@ func StringIsUUID(i interface{}, k cty.Path) diag.Diagnostics {
 
 	return nil
 }
+
+func StringIsSystemOrUUID(i interface{}, k cty.Path) diag.Diagnostics {
+	v, ok := i.(string)
+	if !ok {
+		return diag.Errorf("expected type of %q to be string", k)
+	}
+
+	if v == "system" {
+		return nil
+	}
+
+	if _, err := uuid.ParseUUID(v); err != nil {
+		return diag.Errorf("expected the value \"system\" or a valid UUID, got: %v", v)
+	}
+
+	return nil
+}

--- a/docs/resources/adx_table_update_policy.md
+++ b/docs/resources/adx_table_update_policy.md
@@ -53,7 +53,7 @@ resource "adx_table_update_policy" "test_update" {
 - **query** (String, Required) A query used to produce data for the update
 - **transactional** (Boolean, Required) States if the update policy is transactional or not, default is false). If transactional and the update policy fails, the source table is not updated.
 - **propagate_ingestion_properties** (Boolean, Optional) States if properties specified during ingestion to the source table, such as extent tags and creation time, apply to the target table. Default: false
-- **managed_identity** (String, Optional) An update policy configured with a managed identity is performed on behalf of the managed identity. It must be the reserved word "system" to use the System-assigned Managed Identity of the cluster or an Object ID of an User-assigned Managed Identity.
+- **managed_identity** (String, Optional) An update policy configured with a managed identity is performed on behalf of the managed identity. It must be the reserved word "system" to use the System-assigned Managed Identity of the cluster or an Object ID of a User-assigned Managed Identity.
 - **enabled** (Boolean, Optional) States if update policy is enabled or disabled. Default: true
 - **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
 

--- a/docs/resources/adx_table_update_policy.md
+++ b/docs/resources/adx_table_update_policy.md
@@ -11,6 +11,7 @@ Manages an update policy for a table in ADX.
 
 See: [ADX - Update Policy](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/management/updatepolicy)
 
+
 ## Example Usage
 
 ```terraform
@@ -52,6 +53,7 @@ resource "adx_table_update_policy" "test_update" {
 - **query** (String, Required) A query used to produce data for the update
 - **transactional** (Boolean, Required) States if the update policy is transactional or not, default is false). If transactional and the update policy fails, the source table is not updated.
 - **propagate_ingestion_properties** (Boolean, Optional) States if properties specified during ingestion to the source table, such as extent tags and creation time, apply to the target table. Default: false
+- **managed_identity** (String, Optional) An update policy configured with a managed identity is performed on behalf of the managed identity. It must be the reserved word "system" to use the System-assigned Managed Identity of the cluster or an Object ID of an User-assigned Managed Identity.
 - **enabled** (Boolean, Optional) States if update policy is enabled or disabled. Default: true
 - **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
 


### PR DESCRIPTION
- ability to create an Update Policies with a System- or User-Assigned Managed Identity
- add validation for "system" or uuid of User-Assigned Managed Identity
- update docs