### PR TITLE
fix: allow soft delete period value up to 36500 (days)

### DIFF
--- a/adx/resource_adx_table_retention_policy.go
+++ b/adx/resource_adx_table_retention_policy.go
@@ -47,7 +47,7 @@ func resourceADXTableRetentionPolicy() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateDiagFunc: validate.StringMatch(
-					regexp.MustCompile("[0-9]{1,3}[dhms]"),
+					regexp.MustCompile(`^([1-9]\d{0,3}|[1-2]\d{4}|3[0-5]\d{3}|36[0-4]\d{2}|36500)[dhms]$`),
 					"soft delete timespan must be in the format of <amount><unit> such as 1m for (one minute) or 30d (thirty days)",
 				),
 			},


### PR DESCRIPTION
The Azure portal allows up to 36500, currently we can set it to only 999 days. 
