### PR TITLE
feat: make test database names configurable via env variables

### DIFF
--- a/adx/acceptance.go
+++ b/adx/acceptance.go
@@ -240,6 +240,20 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
+func testAccDatabaseName() string {
+	if v := os.Getenv("ADX_TEST_DATABASE"); v != "" {
+		return v
+	}
+	return "test-db"
+}
+
+func testAccShareableDatabaseName() string {
+	if v := os.Getenv("ADX_TEST_SHAREABLE_DATABASE"); v != "" {
+		return v
+	}
+	return "shareable-db"
+}
+
 func GetAccTestPolicyReadStatementFunc() func(string) (string, error) {
 	return func(id string) (string, error) {
 		policyId, err := parseADXPolicyID(id)

--- a/adx/resource_adx_column_encoding_policy_test.go
+++ b/adx/resource_adx_column_encoding_policy_test.go
@@ -14,7 +14,7 @@ func TestAccADXColumnEncodingPolicy_basic(t *testing.T) {
 	r := ADXColumnEncodingPolicyTestResource{}
 	rtcBuilder := BuildResourceTestContext[ColumnEncodingPolicy]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_column_encoding_policy").
-		DatabaseName("test-db").
+		DatabaseName(testAccDatabaseName()).
 		EntityType("encoding").
 		ReadStatementFunc(GetAccTestPolicyReadStatementFunc()).Build()
 

--- a/adx/resource_adx_function_test.go
+++ b/adx/resource_adx_function_test.go
@@ -14,7 +14,7 @@ func TestAccADXFunction_basic(t *testing.T) {
 	r := ADXFunctionTestResource{}
 	rtcBuilder := BuildResourceTestContext[ADXFunction]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_function").
-		DatabaseName("test-db").
+		DatabaseName(testAccDatabaseName()).
 		EntityType("function").
 		ReadStatementFunc(func(id string) (string, error) {
 			funcId, err := parseADXFunctionID(id)

--- a/adx/resource_adx_materialized_view_caching_policy_test.go
+++ b/adx/resource_adx_materialized_view_caching_policy_test.go
@@ -15,7 +15,7 @@ func TestAccADXMaterializedViewCachingPolicy_basic(t *testing.T) {
 	r := ADXMaterializedViewCachingPolicyTestResource{}
 	rtcBuilder := BuildResourceTestContext[MaterializedViewCachingPolicy]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_materialized_view_caching_policy").
-		DatabaseName("test-db").
+		DatabaseName(testAccDatabaseName()).
 		EntityType("caching").
 		ReadStatementFunc(GetAccTestPolicyReadStatementFunc()).Build()
 
@@ -58,7 +58,7 @@ func TestAccADXMaterializedViewCachingPolicy_follower(t *testing.T) {
 	r := ADXMaterializedViewCachingPolicyTestResource{}
 	rtcBuilder := BuildResourceTestContext[MaterializedViewCachingPolicy]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_materialized_view_caching_policy").
-		DatabaseName("shareable-db").
+		DatabaseName(testAccShareableDatabaseName()).
 		EntityType("caching").
 		EntityName("sample_shared_mv").
 		ReadStatementFunc(GetAccTestPolicyReadStatementFunc()).Build()

--- a/adx/resource_adx_materialized_view_test.go
+++ b/adx/resource_adx_materialized_view_test.go
@@ -15,7 +15,7 @@ func TestAccMaterializedView(t *testing.T) {
 	r := ADXMaterializedViewTestResource{}
 	rtcBuilder := BuildResourceTestContext[ADXMaterializedView]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_materialized_view").
-		DatabaseName("test-db").
+		DatabaseName(testAccDatabaseName()).
 		EntityType("materializedview").
 		ReadStatementFunc(func(id string) (string, error) {
 			viewId, err := parseADXMaterializedViewID(id)
@@ -68,7 +68,7 @@ func TestAccMaterializedView_RLSSourceTable(t *testing.T) {
 	r := ADXMaterializedViewTestResource{}
 	rtcBuilder := BuildResourceTestContext[ADXMaterializedView]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_materialized_view").
-		DatabaseName("test-db").
+		DatabaseName(testAccDatabaseName()).
 		EntityType("materializedview").
 		ReadStatementFunc(func(id string) (string, error) {
 			viewId, err := parseADXMaterializedViewID(id)
@@ -123,7 +123,7 @@ func TestAccMaterializedView_BackfillAsync(t *testing.T) {
 	r := ADXMaterializedViewTestResource{}
 	rtcBuilder := BuildResourceTestContext[ADXMaterializedView]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_materialized_view").
-		DatabaseName("test-db").
+		DatabaseName(testAccDatabaseName()).
 		EntityType("materializedview").
 		ReadStatementFunc(func(id string) (string, error) {
 			viewId, err := parseADXMaterializedViewID(id)

--- a/adx/resource_adx_merge_policy_test.go
+++ b/adx/resource_adx_merge_policy_test.go
@@ -14,7 +14,7 @@ func TestAccADXMergePolicy_table(t *testing.T) {
 	r := ADXMergePolicyTestResource{}
 	rtcBuilder := BuildResourceTestContext[TablePolicy]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_merge_policy").
-		DatabaseName("test-db").
+		DatabaseName(testAccDatabaseName()).
 		EntityType("merge").
 		ReadStatementFunc(GetAccTestPolicyReadStatementFunc()).Build()
 

--- a/adx/resource_adx_table_caching_policy_test.go
+++ b/adx/resource_adx_table_caching_policy_test.go
@@ -14,7 +14,7 @@ func TestAccADXTableCachingPolicy_basic(t *testing.T) {
 	r := ADXTableCachingPolicyTestResource{}
 	rtcBuilder := BuildResourceTestContext[TableCachingPolicy]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_table_caching_policy").
-		DatabaseName("test-db").
+		DatabaseName(testAccDatabaseName()).
 		EntityType("caching").
 		ReadStatementFunc(GetAccTestPolicyReadStatementFunc()).Build()
 
@@ -57,7 +57,7 @@ func TestAccADXTableCachingPolicy_follower(t *testing.T) {
 	r := ADXTableCachingPolicyTestResource{}
 	rtcBuilder := BuildResourceTestContext[TableCachingPolicy]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_table_caching_policy").
-		DatabaseName("shareable-db").
+		DatabaseName(testAccShareableDatabaseName()).
 		EntityType("caching").
 		EntityName("sample_shared_table").
 		ReadStatementFunc(GetAccTestPolicyReadStatementFunc()).Build()

--- a/adx/resource_adx_table_ingestion_batching_policy_test.go
+++ b/adx/resource_adx_table_ingestion_batching_policy_test.go
@@ -14,7 +14,7 @@ func TestAccADXTableIngestionBatchingPolicy_basic(t *testing.T) {
 	r := ADXTableIngestionBatchingPolicyTestResource{}
 	rtcBuilder := BuildResourceTestContext[TableIngestionBatchingPolicy]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_table_ingestion_batching_policy").
-		DatabaseName("test-db").
+		DatabaseName(testAccDatabaseName()).
 		EntityType("ingestionbatching").
 		ReadStatementFunc(GetAccTestPolicyReadStatementFunc()).Build()
 

--- a/adx/resource_adx_table_mapping_test.go
+++ b/adx/resource_adx_table_mapping_test.go
@@ -15,7 +15,7 @@ func TestAccTableMapping_basicJson(t *testing.T) {
 	r := ADXTableMappingTestResource{}
 	rtcBuilder := BuildResourceTestContext[TableMapping]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_table_mapping").
-		DatabaseName("test-db").
+		DatabaseName(testAccDatabaseName()).
 		EntityType("tablemapping").
 		ReadStatementFunc(func(id string) (string, error) {
 			mappingId, err := parseADXTableMappingID(id)
@@ -57,7 +57,7 @@ func TestAccTableMapping_basicCsv(t *testing.T) {
 	r := ADXTableMappingTestResource{}
 	rtcBuilder := BuildResourceTestContext[TableMapping]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_table_mapping").
-		DatabaseName("test-db").
+		DatabaseName(testAccDatabaseName()).
 		EntityType("tablemapping").
 		ReadStatementFunc(func(id string) (string, error) {
 			mappingId, err := parseADXTableMappingID(id)

--- a/adx/resource_adx_table_partitioning_policy_test.go
+++ b/adx/resource_adx_table_partitioning_policy_test.go
@@ -14,7 +14,7 @@ func TestAccADXTablePartitioningPolicy_basic(t *testing.T) {
 	r := ADXTablePartitioningPolicyTestResource{}
 	rtcBuilder := BuildResourceTestContext[TablePartitioningPolicy]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_table_partitioning_policy").
-		DatabaseName("test-db").
+		DatabaseName(testAccDatabaseName()).
 		EntityType("partitioning").
 		ReadStatementFunc(GetAccTestPolicyReadStatementFunc()).Build()
 

--- a/adx/resource_adx_table_restricted_view_policy_test.go
+++ b/adx/resource_adx_table_restricted_view_policy_test.go
@@ -14,7 +14,7 @@ func TestAccADXTableRestrictedViewPolicy_basic(t *testing.T) {
 	r := ADXTableRestrictedViewPolicyTestResource{}
 	rtcBuilder := BuildResourceTestContext[TableRestrictedViewPolicy]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_table_RestrictedView_policy").
-		DatabaseName("test-db").
+		DatabaseName(testAccDatabaseName()).
 		EntityType("RestrictedView").
 		ReadStatementFunc(GetAccTestPolicyReadStatementFunc()).Build()
 
@@ -56,7 +56,7 @@ func TestAccADXTableRestrictedViewPolicy_follower(t *testing.T) {
 	r := ADXTableRestrictedViewPolicyTestResource{}
 	rtcBuilder := BuildResourceTestContext[TableRestrictedViewPolicy]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_table_RestrictedView_policy").
-		DatabaseName("shareable-db").
+		DatabaseName(testAccShareableDatabaseName()).
 		EntityType("RestrictedView").
 		EntityName("sample_shared_table").
 		ReadStatementFunc(GetAccTestPolicyReadStatementFunc()).Build()

--- a/adx/resource_adx_table_streaming_ingestion_policy_test.go
+++ b/adx/resource_adx_table_streaming_ingestion_policy_test.go
@@ -14,7 +14,7 @@ func TestAccADXTableStreamingIngestionPolicy_basic(t *testing.T) {
 	r := ADXTableStreamingIngestionPolicyTestResource{}
 	rtcBuilder := BuildResourceTestContext[TableStreamingIngestionPolicy]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_table_streaming_ingestion_policy").
-		DatabaseName("test-db").
+		DatabaseName(testAccDatabaseName()).
 		EntityType("streamingingestion").
 		ReadStatementFunc(GetAccTestPolicyReadStatementFunc()).Build()
 

--- a/adx/resource_adx_table_test.go
+++ b/adx/resource_adx_table_test.go
@@ -15,7 +15,7 @@ func TestAccADXTable_basic(t *testing.T) {
 	r := ADXTableTestResource{}
 	rtcBuilder := BuildResourceTestContext[TableSchema]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_table").
-		DatabaseName("test-db").
+		DatabaseName(testAccDatabaseName()).
 		EntityType("table").
 		ReadStatementFunc(func(id string) (string, error) {
 			funcId, err := parseADXTableID(id)
@@ -60,7 +60,7 @@ func TestAccADXTable_basic_inline(t *testing.T) {
 	r := ADXTableTestResource{}
 	rtcBuilder := BuildResourceTestContext[TableSchema]()
 	rtc, _ := rtcBuilder.Test(t).Type("adx_table").
-		DatabaseName("test-db").
+		DatabaseName(testAccDatabaseName()).
 		EntityType("table").
 		ReadStatementFunc(func(id string) (string, error) {
 			funcId, err := parseADXTableID(id)


### PR DESCRIPTION
Replace hardcoded 'test-db' and 'shareable-db' in all acceptance tests with helper functions testAccDatabaseName() and testAccShareableDatabaseName().

These read from ADX_TEST_DATABASE and ADX_TEST_SHAREABLE_DATABASE env variables respectively, falling back to the original defaults.

ADX_TEST_SHAREABLE_DATABASE is for testing the follower cluster settings on a shared database.