### PR TITLE
fix: guard against empty update-policy slice in Read to prevent index panic

### DIFF
--- a/adx/resource_adx_table_update_policy.go
+++ b/adx/resource_adx_table_update_policy.go
@@ -119,6 +119,11 @@ func resourceADXTableUpdatePolicyRead(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("error parsing policy update for Table %q (Database %q): %+v", id.Name, id.DatabaseName, err)
 	}
 
+	if len(policy) == 0 {
+		d.SetId("")
+		return diags
+	}
+
 	d.Set("table_name", id.Name)
 	d.Set("database_name", id.DatabaseName)
 	d.Set("enabled", policy[0].IsEnabled)


### PR DESCRIPTION
small fix for a small bug I run in. 

If the KQL database or ADX db returns an empty update-policy array (e.g. policy was never written or hasn't propagated yet), policy[0] would panic with 'index out of range'. Add a length check after unmarshal: if the slice is empty, clear the resource ID so Terraform treats it as non-existent and recreates it on the next apply.