### PR TITLE
fix: resolve database name for Fabric KQL databases

### DIFF
--- a/adx/resource_adx_table.go
+++ b/adx/resource_adx_table.go
@@ -306,7 +306,11 @@ func resourceADXTableRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	d.Set("name", schemas[0].TableName)
-	d.Set("database_name", schemas[0].DatabaseName)
+	resolvedDBName, err := resolveDatabaseName(ctx, meta, clusterConfig, id.DatabaseName, schemas[0].DatabaseName)
+	if err != nil {
+		return diag.Errorf("error resolving database name for Table %q: %+v", id.Name, err)
+	}
+	d.Set("database_name", resolvedDBName)
 	d.Set("table_schema", schemas[0].Schema)
 	d.Set("column", flattenTableColumn(schemas[0].Schema))
 	d.Set("docstring", schemas[0].DocString)

--- a/adx/resource_adx_table_mapping.go
+++ b/adx/resource_adx_table_mapping.go
@@ -202,7 +202,11 @@ func resourceADXTableMappingRead(ctx context.Context, d *schema.ResourceData, me
 
 	d.Set("name", schemas[0].Name)
 	d.Set("table_name", schemas[0].Table)
-	d.Set("database_name", schemas[0].Database)
+	resolvedDBName, err := resolveDatabaseName(ctx, meta, clusterConfig, id.DatabaseName, schemas[0].Database)
+	if err != nil {
+		return diag.Errorf("error resolving database name for Table Mapping %q: %+v", id.MappingName, err)
+	}
+	d.Set("database_name", resolvedDBName)
 	d.Set("kind", strings.ToLower(schemas[0].Kind))
 	d.Set("mapping", flattenTableMapping(schemas[0].Mapping))
 	d.Set("last_updated_on", schemas[0].LastUpdatedOn.String())

--- a/adx/utils.go
+++ b/adx/utils.go
@@ -339,3 +339,35 @@ func unescapeEntityName(name string) string {
 	}
 	return name
 }
+
+var uuidPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+func isUUID(s string) bool {
+	return uuidPattern.MatchString(s)
+}
+
+type DatabaseIdentity struct {
+	DatabaseName string
+	PrettyName   string
+}
+
+// resolveDatabaseName resolves the database name from an API response.
+// Fabric KQL databases return a UUID as DatabaseName in responses like
+// .show table cslschema. In that case, we query .show database to get
+// the PrettyName which contains the actual database name.
+func resolveDatabaseName(ctx context.Context, meta interface{}, clusterConfig *ClusterConfig, queryDatabaseName string, apiDatabaseName string) (string, error) {
+	if !isUUID(apiDatabaseName) {
+		return apiDatabaseName, nil
+	}
+
+	dbInfo, err := queryADXMgmtAndParse[DatabaseIdentity](ctx, meta, clusterConfig, queryDatabaseName, ".show database")
+	if err != nil {
+		return apiDatabaseName, fmt.Errorf("error resolving database name: %+v", err)
+	}
+
+	if len(dbInfo) > 0 && dbInfo[0].PrettyName != "" {
+		return dbInfo[0].PrettyName, nil
+	}
+
+	return apiDatabaseName, nil
+}


### PR DESCRIPTION
Fabric KQL databases return a UUID as DatabaseName in API responses like .show table cslschema. This causes Terraform to detect a diff and force resource replacement on every plan.

Added resolveDatabaseName() utility that detects UUID database names and queries .show database to retrieve the PrettyName, which contains the actual user-facing database name. Standard ADX database names are passed through unchanged.