### PR TITLE
fix: increase soft_delete_period limit to 999 years (364635 days)

### DIFF
--- a/adx/resource_adx_materialized_view_retention_policy.go
+++ b/adx/resource_adx_materialized_view_retention_policy.go
@@ -47,8 +47,8 @@ func resourceADXMaterializedViewRetentionPolicy() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateDiagFunc: validate.StringMatch(
-					regexp.MustCompile("[0-9]{1,3}[dhms]"),
-					"soft delete timespan must be in the format of <amount><unit> such as 1m for (one minute) or 30d (thirty days)",
+					regexp.MustCompile(`^([1-9]\d{0,4}|[1-2]\d{5}|3[0-4]\d{4}|35\d{4}|36[0-3]\d{3}|364[0-5]\d{2}|3646[0-2]\d|36463[0-5])[dhms]$`),
+					"soft delete timespan must be in the format of <amount><unit> such as 1m for (one minute) or 30d (thirty days), maximum is 364635d (999 years)",
 				),
 			},
 

--- a/adx/resource_adx_table_retention_policy.go
+++ b/adx/resource_adx_table_retention_policy.go
@@ -47,8 +47,8 @@ func resourceADXTableRetentionPolicy() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateDiagFunc: validate.StringMatch(
-					regexp.MustCompile(`^([1-9]\d{0,3}|[1-2]\d{4}|3[0-5]\d{3}|36[0-4]\d{2}|36500)[dhms]$`),
-					"soft delete timespan must be in the format of <amount><unit> such as 1m for (one minute) or 30d (thirty days)",
+					regexp.MustCompile(`^([1-9]\d{0,4}|[1-2]\d{5}|3[0-4]\d{4}|35\d{4}|36[0-3]\d{3}|364[0-5]\d{2}|3646[0-2]\d|36463[0-5])[dhms]$`),
+					"soft delete timespan must be in the format of <amount><unit> such as 1m for (one minute) or 30d (thirty days), maximum is 364635d (999 years)",
 				),
 			},
 


### PR DESCRIPTION
The previous cap of 36500 (100 years) was arbitrary and undocumented. Kusto supports up to 1000 years; align our validation to 999 years (364635 days) for both adx_table_retention_policy and adx_materialized_view_retention_policy.

Also fixes the materialized view regex which was unanchored and only allowed up to 3 digits (max 999 of any unit).