### PR TITLE
feat: add workload group and cluster request classification policy resources

### DIFF
--- a/adx/provider.go
+++ b/adx/provider.go
@@ -53,6 +53,8 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"adx_cluster_request_classification_policy": resourceADXClusterRequestClassificationPolicy(),
+
 			"adx_column_encoding_policy": resourceADXColumnEncodingPolicy(),
 
 			"adx_external_table": resourceADXExternalTable(),
@@ -79,6 +81,8 @@ func Provider() *schema.Provider {
 			"adx_table_security_role":              	resourceADXTableSecurityRole(),
 			"adx_table_streaming_ingestion_policy": 	resourceADXTableStreamingIngestionPolicy(),
 			"adx_table_update_policy":              	resourceADXTableUpdatePolicy(),
+
+			"adx_workload_group": resourceADXWorkloadGroup(),
 		},
 	}
 

--- a/adx/resource_adx_cluster_request_classification_policy.go
+++ b/adx/resource_adx_cluster_request_classification_policy.go
@@ -1,0 +1,147 @@
+package adx
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-kusto-go/kusto"
+	"github.com/Azure/azure-kusto-go/kusto/unsafe"
+	"github.com/favoretti/terraform-provider-adx/adx/validate"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type ADXRequestClassificationPolicy struct {
+	PolicyName    string
+	EntityName    string
+	Policy        string
+	ChildEntities string
+	EntityType    string
+}
+
+type requestClassificationPolicyObject struct {
+	IsEnabled                bool     `json:"IsEnabled"`
+	ClassificationFunction   string   `json:"ClassificationFunction,omitempty"`
+	ClassificationProperties []string `json:"ClassificationProperties,omitempty"`
+}
+
+func resourceADXClusterRequestClassificationPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceADXClusterRequestClassificationPolicyCreateUpdate,
+		ReadContext:   resourceADXClusterRequestClassificationPolicyRead,
+		UpdateContext: resourceADXClusterRequestClassificationPolicyCreateUpdate,
+		DeleteContext: resourceADXClusterRequestClassificationPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cluster": getClusterConfigInputSchema(),
+			"database_name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+				Description:      "Database name used as context for the management command. The policy is cluster-level.",
+			},
+			"is_enabled": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: "Whether the request classification policy is enabled.",
+			},
+			"classification_function": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+				DiffSuppressFunc: suppressClassificationFunctionDiff,
+				Description:      "The body of the KQL function used for classifying requests into workload groups.",
+			},
+		},
+		CustomizeDiff: clusterConfigCustomDiff,
+	}
+}
+
+func resourceADXClusterRequestClassificationPolicyCreateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clusterConfig := getAndExpandClusterConfigWithDefaults(ctx, d, meta)
+	databaseName := d.Get("database_name").(string)
+	isEnabled := d.Get("is_enabled").(bool)
+	classificationFunction := d.Get("classification_function").(string)
+
+	policyJSON := fmt.Sprintf(`{"IsEnabled":%t}`, isEnabled)
+	createStatement := fmt.Sprintf(".alter cluster policy request_classification '%s' <|\n%s", policyJSON, classificationFunction)
+
+	client, err := getADXClient(meta, clusterConfig)
+	if err != nil {
+		return diag.Errorf("error creating adx client connection: %+v", err)
+	}
+
+	kStmtOpts := kusto.UnsafeStmt(unsafe.Stmt{Add: true})
+	_, err = client.Mgmt(ctx, databaseName, kusto.NewStmt("", kStmtOpts).UnsafeAdd(createStatement))
+	if err != nil {
+		return diag.Errorf("error creating/updating cluster request classification policy (Database %q): %+v", databaseName, err)
+	}
+
+	d.SetId(buildADXResourceId(clusterConfig.URI, databaseName, "cluster", "request_classification"))
+
+	return resourceADXClusterRequestClassificationPolicyRead(ctx, d, meta)
+}
+
+func resourceADXClusterRequestClassificationPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clusterConfig := getAndExpandClusterConfigWithDefaults(ctx, d, meta)
+
+	id, err := parseADXClusterRequestClassificationPolicyID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	showCommand := ".show cluster policy request_classification"
+	resultSet, diags := readADXEntity[ADXRequestClassificationPolicy](ctx, meta, clusterConfig, id, showCommand, "cluster")
+	if diags.HasError() {
+		return diags
+	}
+
+	if len(resultSet) < 1 || resultSet[0].Policy == "" || resultSet[0].Policy == "null" {
+		d.SetId("")
+		return diags
+	}
+
+	var policy requestClassificationPolicyObject
+	if err := json.Unmarshal([]byte(resultSet[0].Policy), &policy); err != nil {
+		return diag.Errorf("error parsing cluster request classification policy: %+v", err)
+	}
+
+	d.Set("database_name", id.DatabaseName)
+	d.Set("is_enabled", policy.IsEnabled)
+	d.Set("classification_function", policy.ClassificationFunction)
+
+	return diags
+}
+
+func resourceADXClusterRequestClassificationPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clusterConfig := getAndExpandClusterConfigWithDefaults(ctx, d, meta)
+
+	id, err := parseADXClusterRequestClassificationPolicyID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	deleteStatement := ".delete cluster policy request_classification"
+	return deleteADXEntity(ctx, d, meta, clusterConfig, id.DatabaseName, deleteStatement)
+}
+
+func parseADXClusterRequestClassificationPolicyID(input string) (*adxResourceId, error) {
+	return parseADXResourceID(input, 4, 0, 1, 2, 3)
+}
+
+// suppressClassificationFunctionDiff compares classification functions by normalizing whitespace.
+func suppressClassificationFunctionDiff(k, old, new string, d *schema.ResourceData) bool {
+	return normalizeWhitespace(old) == normalizeWhitespace(new)
+}
+
+// normalizeWhitespace collapses all runs of whitespace into single spaces and trims.
+func normalizeWhitespace(s string) string {
+	fields := strings.Fields(s)
+	return strings.Join(fields, " ")
+}

--- a/adx/resource_adx_cluster_request_classification_policy_test.go
+++ b/adx/resource_adx_cluster_request_classification_policy_test.go
@@ -1,0 +1,135 @@
+package adx
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+type ADXClusterRequestClassificationPolicyTestResource struct{}
+
+func TestAccADXClusterRequestClassificationPolicy_basic(t *testing.T) {
+	r := ADXClusterRequestClassificationPolicyTestResource{}
+	databaseName := testAccDatabaseName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: r.checkDestroy(databaseName),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					r.checkExists("adx_cluster_request_classification_policy.test"),
+					resource.TestCheckResourceAttr("adx_cluster_request_classification_policy.test", "database_name", databaseName),
+					resource.TestCheckResourceAttr("adx_cluster_request_classification_policy.test", "is_enabled", "true"),
+				),
+			},
+			{
+				Config: r.update(databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					r.checkExists("adx_cluster_request_classification_policy.test"),
+					resource.TestCheckResourceAttr("adx_cluster_request_classification_policy.test", "database_name", databaseName),
+					resource.TestCheckResourceAttr("adx_cluster_request_classification_policy.test", "is_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      "adx_cluster_request_classification_policy.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func (this ADXClusterRequestClassificationPolicyTestResource) basic(databaseName string) string {
+	return fmt.Sprintf(`
+	resource "adx_cluster_request_classification_policy" "test" {
+		database_name = "%s"
+		is_enabled    = true
+
+		classification_function = <<-EOT
+			iff(request_properties.current_application == "Kusto.Explorer" and request_properties.request_type == "Query",
+				"Ad-hoc queries",
+				"default")
+		EOT
+	}
+	`, databaseName)
+}
+
+func (this ADXClusterRequestClassificationPolicyTestResource) update(databaseName string) string {
+	return fmt.Sprintf(`
+	resource "adx_cluster_request_classification_policy" "test" {
+		database_name = "%s"
+		is_enabled    = true
+
+		classification_function = <<-EOT
+			case(
+				request_properties.current_application == "Kusto.Explorer" and request_properties.request_type == "Query", "Ad-hoc queries",
+				request_properties.current_application == "KustoQueryRunner", "Scheduled",
+				"default")
+		EOT
+	}
+	`, databaseName)
+}
+
+func (this ADXClusterRequestClassificationPolicyTestResource) checkExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("ID is not set for %s", resourceName)
+		}
+
+		id, err := parseADXClusterRequestClassificationPolicyID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		clusterConfig := GetTestClusterConfig()
+		resultSet, err := queryADXMgmtAndParse[ADXRequestClassificationPolicy](
+			context.Background(), testAccProvider.Meta(), clusterConfig, id.DatabaseName,
+			".show cluster policy request_classification",
+		)
+		if err != nil {
+			return fmt.Errorf("error reading cluster request classification policy: %+v", err)
+		}
+		if len(resultSet) == 0 || resultSet[0].Policy == "" || resultSet[0].Policy == "null" {
+			return fmt.Errorf("cluster request classification policy does not exist")
+		}
+
+		return nil
+	}
+}
+
+func (this ADXClusterRequestClassificationPolicyTestResource) checkDestroy(databaseName string) func(*terraform.State) error {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "adx_cluster_request_classification_policy" {
+				continue
+			}
+
+			clusterConfig := GetTestClusterConfig()
+			resultSet, err := queryADXMgmtAndParse[ADXRequestClassificationPolicy](
+				context.Background(), testAccProvider.Meta(), clusterConfig, databaseName,
+				".show cluster policy request_classification",
+			)
+			if err != nil {
+				if strings.Contains(err.Error(), "BadRequest_EntityNotFound") {
+					continue
+				}
+				return fmt.Errorf("error checking cluster request classification policy destroyed: %+v", err)
+			}
+			if len(resultSet) > 0 && resultSet[0].Policy != "" && resultSet[0].Policy != "null" {
+				return fmt.Errorf("cluster request classification policy still exists")
+			}
+		}
+		return nil
+	}
+}

--- a/adx/resource_adx_workload_group.go
+++ b/adx/resource_adx_workload_group.go
@@ -1,0 +1,264 @@
+package adx
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/Azure/azure-kusto-go/kusto"
+	"github.com/Azure/azure-kusto-go/kusto/unsafe"
+	"github.com/favoretti/terraform-provider-adx/adx/validate"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type ADXWorkloadGroup struct {
+	WorkloadGroupName string
+	WorkloadGroup     string
+}
+
+func resourceADXWorkloadGroup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceADXWorkloadGroupCreateUpdate,
+		ReadContext:   resourceADXWorkloadGroupRead,
+		UpdateContext: resourceADXWorkloadGroupCreateUpdate,
+		DeleteContext: resourceADXWorkloadGroupDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cluster": getClusterConfigInputSchema(),
+			"database_name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+				Description:      "Database name used as context for the management command. Workload groups are cluster-level resources.",
+			},
+			"name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.StringIsNotEmpty,
+				Description:      "Name of the workload group.",
+			},
+			"request_limits_policy": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validate.StringIsJSON,
+				DiffSuppressFunc: suppressJSONDiff,
+				Description:      "JSON representation of the request limits policy.",
+			},
+			"request_rate_limit_policies": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validate.StringIsJSON,
+				DiffSuppressFunc: suppressJSONDiff,
+				Description:      "JSON representation of the request rate limit policies array.",
+			},
+			"request_rate_limits_enforcement_policy": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validate.StringIsJSON,
+				DiffSuppressFunc: suppressJSONDiff,
+				Description:      "JSON representation of the request rate limits enforcement policy.",
+			},
+			"request_queuing_policy": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validate.StringIsJSON,
+				DiffSuppressFunc: suppressJSONDiff,
+				Description:      "JSON representation of the request queuing policy.",
+			},
+			"query_consistency_policy": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validate.StringIsJSON,
+				DiffSuppressFunc: suppressJSONDiff,
+				Description:      "JSON representation of the query consistency policy.",
+			},
+		},
+		CustomizeDiff: clusterConfigCustomDiff,
+	}
+}
+
+func resourceADXWorkloadGroupCreateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clusterConfig := getAndExpandClusterConfigWithDefaults(ctx, d, meta)
+	name := d.Get("name").(string)
+	databaseName := d.Get("database_name").(string)
+
+	policyObject := buildWorkloadGroupPolicyObject(d)
+
+	escapedName := escapeEntityNameIfRequired(name)
+	createStatement := fmt.Sprintf(".create-or-alter workload_group %s ```\n%s\n```", escapedName, policyObject)
+
+	client, err := getADXClient(meta, clusterConfig)
+	if err != nil {
+		return diag.Errorf("error creating adx client connection: %+v", err)
+	}
+
+	kStmtOpts := kusto.UnsafeStmt(unsafe.Stmt{Add: true})
+	_, err = client.Mgmt(ctx, databaseName, kusto.NewStmt("", kStmtOpts).UnsafeAdd(createStatement))
+	if err != nil {
+		return diag.Errorf("error creating/updating workload group %q (Database %q): %+v", name, databaseName, err)
+	}
+
+	d.SetId(buildADXResourceId(clusterConfig.URI, databaseName, "workload_group", name))
+
+	return resourceADXWorkloadGroupRead(ctx, d, meta)
+}
+
+func resourceADXWorkloadGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clusterConfig := getAndExpandClusterConfigWithDefaults(ctx, d, meta)
+
+	id, err := parseADXWorkloadGroupID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	showCommand := fmt.Sprintf(".show workload_group %s", escapeEntityNameIfRequired(id.Name))
+	resultSet, diags := readADXEntity[ADXWorkloadGroup](ctx, meta, clusterConfig, id, showCommand, "workload_group")
+	if diags.HasError() {
+		return diags
+	}
+
+	if len(resultSet) < 1 {
+		d.SetId("")
+		return diags
+	}
+
+	d.Set("name", resultSet[0].WorkloadGroupName)
+	d.Set("database_name", id.DatabaseName)
+
+	flattenWorkloadGroupPolicies(d, resultSet[0].WorkloadGroup)
+
+	return diags
+}
+
+func resourceADXWorkloadGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clusterConfig := getAndExpandClusterConfigWithDefaults(ctx, d, meta)
+
+	id, err := parseADXWorkloadGroupID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	deleteStatement := fmt.Sprintf(".drop workload_group %s", escapeEntityNameIfRequired(id.Name))
+	return deleteADXEntity(ctx, d, meta, clusterConfig, id.DatabaseName, deleteStatement)
+}
+
+func parseADXWorkloadGroupID(input string) (*adxResourceId, error) {
+	return parseADXResourceID(input, 4, 0, 1, 2, 3)
+}
+
+func buildWorkloadGroupPolicyObject(d *schema.ResourceData) string {
+	var parts []string
+
+	if v, ok := d.GetOk("request_limits_policy"); ok {
+		parts = append(parts, fmt.Sprintf(`"RequestLimitsPolicy": %s`, normalizeJSON(v.(string))))
+	}
+	if v, ok := d.GetOk("request_rate_limit_policies"); ok {
+		parts = append(parts, fmt.Sprintf(`"RequestRateLimitPolicies": %s`, normalizeJSON(v.(string))))
+	}
+	if v, ok := d.GetOk("request_rate_limits_enforcement_policy"); ok {
+		parts = append(parts, fmt.Sprintf(`"RequestRateLimitsEnforcementPolicy": %s`, normalizeJSON(v.(string))))
+	}
+	if v, ok := d.GetOk("request_queuing_policy"); ok {
+		parts = append(parts, fmt.Sprintf(`"RequestQueuingPolicy": %s`, normalizeJSON(v.(string))))
+	}
+	if v, ok := d.GetOk("query_consistency_policy"); ok {
+		parts = append(parts, fmt.Sprintf(`"QueryConsistencyPolicy": %s`, normalizeJSON(v.(string))))
+	}
+
+	return fmt.Sprintf("{%s}", strings.Join(parts, ", "))
+}
+
+func flattenWorkloadGroupPolicies(d *schema.ResourceData, workloadGroupJSON string) {
+	policies := parseWorkloadGroupJSON(workloadGroupJSON)
+
+	policyFields := map[string]string{
+		"RequestLimitsPolicy":                "request_limits_policy",
+		"RequestRateLimitPolicies":           "request_rate_limit_policies",
+		"RequestRateLimitsEnforcementPolicy": "request_rate_limits_enforcement_policy",
+		"RequestQueuingPolicy":               "request_queuing_policy",
+		"QueryConsistencyPolicy":             "query_consistency_policy",
+	}
+
+	for apiKey, tfKey := range policyFields {
+		if v, ok := policies[apiKey]; ok && v != "null" {
+			d.Set(tfKey, v)
+		}
+	}
+}
+
+// parseWorkloadGroupJSON parses the workload group JSON and extracts individual policy sections.
+func parseWorkloadGroupJSON(input string) map[string]string {
+	result := make(map[string]string)
+
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(input), &parsed); err != nil {
+		return result
+	}
+
+	for key, val := range parsed {
+		if string(val) == "null" {
+			result[key] = "null"
+			continue
+		}
+		result[key] = string(val)
+	}
+
+	return result
+}
+
+// suppressJSONDiff suppresses diffs when the shared keys between config and state
+// have equal values. This handles:
+// - Whitespace/formatting differences (compact vs pretty JSON)
+// - API returning extra server-side default fields not in the user config
+// - API not returning fields that the user set (accepted but not echoed back)
+// A real change (user modifies a value) is still detected because shared keys will differ.
+func suppressJSONDiff(k, old, new string, d *schema.ResourceData) bool {
+	var oldJSON, newJSON interface{}
+	if err := json.Unmarshal([]byte(old), &oldJSON); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(new), &newJSON); err != nil {
+		return false
+	}
+	return jsonIsSubset(newJSON, oldJSON) || jsonIsSubset(oldJSON, newJSON)
+}
+
+// jsonIsSubset checks if 'subset' is semantically contained in 'superset'.
+// For objects: every key in subset must exist in superset with a matching value.
+// For arrays: must be deeply equal.
+// For scalars: must be deeply equal.
+func jsonIsSubset(subset, superset interface{}) bool {
+	subMap, subOk := subset.(map[string]interface{})
+	supMap, supOk := superset.(map[string]interface{})
+	if subOk && supOk {
+		for key, subVal := range subMap {
+			supVal, exists := supMap[key]
+			if !exists || !jsonIsSubset(subVal, supVal) {
+				return false
+			}
+		}
+		return true
+	}
+	return reflect.DeepEqual(subset, superset)
+}
+
+// normalizeJSON compacts JSON to a canonical form for consistent API calls.
+func normalizeJSON(input string) string {
+	var parsed interface{}
+	if err := json.Unmarshal([]byte(input), &parsed); err != nil {
+		return input
+	}
+	result, err := json.Marshal(parsed)
+	if err != nil {
+		return input
+	}
+	return string(result)
+}

--- a/adx/resource_adx_workload_group_test.go
+++ b/adx/resource_adx_workload_group_test.go
@@ -1,0 +1,223 @@
+package adx
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+type ADXWorkloadGroupTestResource struct{}
+
+func TestAccADXWorkloadGroup_basic(t *testing.T) {
+	var entity ADXWorkloadGroup
+	r := ADXWorkloadGroupTestResource{}
+	rtcBuilder := BuildResourceTestContext[ADXWorkloadGroup]()
+	rtc, _ := rtcBuilder.Test(t).Type("adx_workload_group").
+		DatabaseName(testAccDatabaseName()).
+		EntityType("workload_group").
+		ReadStatementFunc(func(id string) (string, error) {
+			wgId, err := parseADXWorkloadGroupID(id)
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf(".show workload_group %s", escapeEntityNameIfRequired(wgId.Name)), nil
+		}).Build()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: rtc.GetTestCheckEntityDestroyed(),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(rtc),
+				Check: resource.ComposeTestCheckFunc(
+					rtc.GetTestCheckEntityExists(&entity),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "name", rtc.EntityName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
+				),
+			},
+			{
+				Config: r.update(rtc),
+				Check: resource.ComposeTestCheckFunc(
+					rtc.GetTestCheckEntityExists(&entity),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "name", rtc.EntityName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
+				),
+			},
+			{
+				ResourceName:      rtc.GetTFName(),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccADXWorkloadGroup_full(t *testing.T) {
+	var entity ADXWorkloadGroup
+	r := ADXWorkloadGroupTestResource{}
+	rtcBuilder := BuildResourceTestContext[ADXWorkloadGroup]()
+	rtc, _ := rtcBuilder.Test(t).Type("adx_workload_group").
+		DatabaseName(testAccDatabaseName()).
+		EntityType("workload_group").
+		ReadStatementFunc(func(id string) (string, error) {
+			wgId, err := parseADXWorkloadGroupID(id)
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf(".show workload_group %s", escapeEntityNameIfRequired(wgId.Name)), nil
+		}).Build()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: rtc.GetTestCheckEntityDestroyed(),
+		Steps: []resource.TestStep{
+			{
+				Config: r.full(rtc),
+				Check: resource.ComposeTestCheckFunc(
+					rtc.GetTestCheckEntityExists(&entity),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "name", rtc.EntityName),
+					resource.TestCheckResourceAttr(rtc.GetTFName(), "database_name", rtc.DatabaseName),
+				),
+			},
+			{
+				ResourceName:      rtc.GetTFName(),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func (this ADXWorkloadGroupTestResource) basic(rtc *ResourceTestContext[ADXWorkloadGroup]) string {
+	return fmt.Sprintf(`
+	resource "%s" %s {
+		database_name = "%s"
+		name          = "%s"
+
+		request_rate_limit_policies = jsonencode([
+			{
+				IsEnabled = true
+				Scope     = "WorkloadGroup"
+				LimitKind = "ConcurrentRequests"
+				Properties = {
+					MaxConcurrentRequests = 100
+				}
+			}
+		])
+	}
+	`, rtc.Type, rtc.Label, rtc.DatabaseName, rtc.EntityName)
+}
+
+func (this ADXWorkloadGroupTestResource) update(rtc *ResourceTestContext[ADXWorkloadGroup]) string {
+	return fmt.Sprintf(`
+	resource "%s" %s {
+		database_name = "%s"
+		name          = "%s"
+
+		request_rate_limit_policies = jsonencode([
+			{
+				IsEnabled = true
+				Scope     = "WorkloadGroup"
+				LimitKind = "ConcurrentRequests"
+				Properties = {
+					MaxConcurrentRequests = 50
+				}
+			},
+			{
+				IsEnabled = true
+				Scope     = "Principal"
+				LimitKind = "ConcurrentRequests"
+				Properties = {
+					MaxConcurrentRequests = 10
+				}
+			}
+		])
+	}
+	`, rtc.Type, rtc.Label, rtc.DatabaseName, rtc.EntityName)
+}
+
+func (this ADXWorkloadGroupTestResource) full(rtc *ResourceTestContext[ADXWorkloadGroup]) string {
+	return fmt.Sprintf(`
+	resource "%s" %s {
+		database_name = "%s"
+		name          = "%s"
+
+		request_limits_policy = jsonencode({
+			DataScope = {
+				IsRelaxable = true
+				Value       = "HotCache"
+			}
+			MaxMemoryPerQueryPerNode = {
+				IsRelaxable = true
+				Value       = 6442450944
+			}
+			MaxMemoryPerIterator = {
+				IsRelaxable = true
+				Value       = 5368709120
+			}
+			MaxFanoutThreadsPercentage = {
+				IsRelaxable = true
+				Value       = 100
+			}
+			MaxFanoutNodesPercentage = {
+				IsRelaxable = true
+				Value       = 100
+			}
+			MaxResultRecords = {
+				IsRelaxable = true
+				Value       = 500000
+			}
+			MaxResultBytes = {
+				IsRelaxable = true
+				Value       = 67108864
+			}
+			MaxExecutionTime = {
+				IsRelaxable = true
+				Value       = "00:04:00"
+			}
+		})
+
+		request_rate_limit_policies = jsonencode([
+			{
+				IsEnabled = true
+				Scope     = "WorkloadGroup"
+				LimitKind = "ConcurrentRequests"
+				Properties = {
+					MaxConcurrentRequests = 100
+				}
+			},
+			{
+				IsEnabled = true
+				Scope     = "Principal"
+				LimitKind = "ConcurrentRequests"
+				Properties = {
+					MaxConcurrentRequests = 25
+				}
+			}
+		])
+
+		request_rate_limits_enforcement_policy = jsonencode({
+			QueriesEnforcementLevel  = "QueryHead"
+			CommandsEnforcementLevel = "Database"
+		})
+
+		request_queuing_policy = jsonencode({
+			IsEnabled = true
+		})
+
+		query_consistency_policy = jsonencode({
+			QueryConsistency = {
+				IsRelaxable = true
+				Value       = "Weak"
+			}
+			CachedResultsMaxAge = {
+				IsRelaxable = true
+				Value       = "00:05:00"
+			}
+		})
+	}
+	`, rtc.Type, rtc.Label, rtc.DatabaseName, rtc.EntityName)
+}

--- a/adx/validate/validate.go
+++ b/adx/validate/validate.go
@@ -1,6 +1,7 @@
 package validate
 
 import (
+	"encoding/json"
 	"regexp"
 
 	"github.com/hashicorp/go-cty/cty"
@@ -97,6 +98,20 @@ func StringIsSystemOrUUID(i interface{}, k cty.Path) diag.Diagnostics {
 
 	if _, err := uuid.ParseUUID(v); err != nil {
 		return diag.Errorf("expected the value \"system\" or a valid UUID, got: %v", v)
+	}
+
+	return nil
+}
+
+func StringIsJSON(i interface{}, k cty.Path) diag.Diagnostics {
+	v, ok := i.(string)
+	if !ok {
+		return diag.Errorf("expected type of %q to be string", k)
+	}
+
+	var js interface{}
+	if err := json.Unmarshal([]byte(v), &js); err != nil {
+		return diag.Errorf("expected %q to be valid JSON: %s", k, err)
 	}
 
 	return nil

--- a/docs/resources/adx_cluster_request_classification_policy.md
+++ b/docs/resources/adx_cluster_request_classification_policy.md
@@ -1,0 +1,84 @@
+---
+page_title: "adx_cluster_request_classification_policy Resource - terraform-provider-adx"
+subcategory: ""
+description: |-
+  Manages the cluster-level request classification policy in ADX.
+---
+
+# Resource `adx_cluster_request_classification_policy`
+
+Manages the cluster-level request classification policy in ADX (Azure Data Explorer). The request classification policy assigns incoming requests to workload groups based on request characteristics using a user-defined KQL function.
+
+See: [ADX - Request Classification Policy](https://learn.microsoft.com/en-us/kusto/management/request-classification-policy)
+
+## Example Usage
+
+### Simple classification to a single workload group
+
+```terraform
+resource "adx_cluster_request_classification_policy" "example" {
+  database_name = "my-database"
+  is_enabled    = true
+
+  classification_function = <<-EOT
+    iff(request_properties.current_application == "Kusto.Explorer" and request_properties.request_type == "Query",
+        "Ad-hoc queries",
+        "default")
+  EOT
+}
+```
+
+### Classification to multiple workload groups
+
+```terraform
+resource "adx_cluster_request_classification_policy" "example" {
+  database_name = "my-database"
+  is_enabled    = true
+
+  classification_function = <<-EOT
+    case(
+      current_principal_is_member_of('aadgroup=admins@contoso.com'), "Premium",
+      request_properties.current_database == "Analytics" and request_properties.current_principal has 'aadapp=', "Automated",
+      request_properties.current_application == "Kusto.Explorer" and request_properties.request_type == "Query", "Ad-hoc queries",
+      request_properties.current_application == "KustoQueryRunner", "Scheduled",
+      "default")
+  EOT
+}
+```
+
+## Argument Reference
+
+- **database_name** (String, Required) Database name used as context for the management command. The policy is cluster-level.
+- **is_enabled** (Bool, Required) Whether the request classification policy is enabled.
+- **classification_function** (String, Required) The body of the KQL function used for classifying requests into workload groups. The function must return a string (the workload group name) and has access to `request_properties` with fields like `current_database`, `current_application`, `current_principal`, `request_type`, `request_description`, etc.
+- **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
+
+`cluster` Configuration block for connection details about the target ADX cluster
+
+*Note*: Any attributes specified here override the cluster config specified in the provider. Once a resource overrides an attribute specified in the provider, it will be stored explicitly as state for that resource and will not be possible to go back to the provider config unless explicitly unset.
+
+- **uri** - (String, Optional) Target ADX cluster endpoint URI, starting with `https://`
+- **client_id** - (String, Optional) The client ID for a service principal having admin access to this cluster/database.
+- **client_secret** - (String, Optional) The client secret for a service principal having admin access to this cluster/database
+- **tenant_id** - (String, Optional) Id for the tenant to which the service principal belongs
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- **id** - The ID of this resource.
+
+## Import
+
+The cluster request classification policy can be imported using the resource ID format:
+
+```shell
+terraform import adx_cluster_request_classification_policy.example <cluster_endpoint>|<database_name>|cluster|request_classification
+```
+
+## Notes
+
+- Only one request classification policy can be defined per cluster.
+- The classification function is evaluated for every incoming request — keep it lightweight.
+- The function must not reference any other entity (database, table, or function).
+- If the function returns an empty string, "default", or a non-existent workload group name, the request is assigned to the `default` workload group.

--- a/docs/resources/adx_workload_group.md
+++ b/docs/resources/adx_workload_group.md
@@ -1,0 +1,126 @@
+---
+page_title: "adx_workload_group Resource - terraform-provider-adx"
+subcategory: ""
+description: |-
+  Manages a workload group in ADX.
+---
+
+# Resource `adx_workload_group`
+
+Manages a workload group in ADX (Azure Data Explorer). Workload groups allow you to group together sets of management commands and queries based on shared characteristics, and apply policies to control per-request limits and request rate limits.
+
+See: [ADX - Workload Groups](https://learn.microsoft.com/en-us/kusto/management/workload-groups)
+
+## Example Usage
+
+### Basic workload group with request rate limits
+
+```terraform
+resource "adx_workload_group" "adhoc_queries" {
+  database_name = "my-database"
+  name          = "Ad-hoc queries"
+
+  request_rate_limit_policies = jsonencode([
+    {
+      IsEnabled = true
+      Scope     = "WorkloadGroup"
+      LimitKind = "ConcurrentRequests"
+      Properties = {
+        MaxConcurrentRequests = 100
+      }
+    },
+    {
+      IsEnabled = true
+      Scope     = "Principal"
+      LimitKind = "ConcurrentRequests"
+      Properties = {
+        MaxConcurrentRequests = 25
+      }
+    }
+  ])
+}
+```
+
+### Workload group with request limits and rate limits
+
+```terraform
+resource "adx_workload_group" "reports" {
+  database_name = "my-database"
+  name          = "Reports"
+
+  request_limits_policy = jsonencode({
+    DataScope = {
+      IsRelaxable = true
+      Value       = "HotCache"
+    }
+    MaxMemoryPerQueryPerNode = {
+      IsRelaxable = false
+      Value       = 6442450944
+    }
+    MaxExecutionTime = {
+      IsRelaxable = true
+      Value       = "00:04:00"
+    }
+    MaxResultRecords = {
+      IsRelaxable = true
+      Value       = 500000
+    }
+    MaxResultBytes = {
+      IsRelaxable = true
+      Value       = 67108864
+    }
+  })
+
+  request_rate_limit_policies = jsonencode([
+    {
+      IsEnabled = true
+      Scope     = "WorkloadGroup"
+      LimitKind = "ConcurrentRequests"
+      Properties = {
+        MaxConcurrentRequests = 50
+      }
+    }
+  ])
+
+  query_consistency_policy = jsonencode({
+    QueryConsistency = {
+      IsRelaxable = true
+      Value       = "Weak"
+    }
+  })
+}
+```
+
+## Argument Reference
+
+- **name** (String, Required) Name of the workload group. Up to 16 custom workload groups can be defined per cluster.
+- **database_name** (String, Required) Database name used as context for the management command. Workload groups are cluster-level resources.
+- **request_limits_policy** (String, Optional) JSON representation of the request limits policy. Controls per-request resource limits such as memory, execution time, and result size.
+- **request_rate_limit_policies** (String, Optional) JSON representation of the request rate limit policies array. Controls how many concurrent requests are allowed per workload group or principal.
+- **request_rate_limits_enforcement_policy** (String, Optional) JSON representation of the request rate limits enforcement policy. Controls at which level (Cluster, Database, QueryHead) rate limits are enforced.
+- **request_queuing_policy** (String, Optional) JSON representation of the request queuing policy. When enabled, requests are queued instead of rejected when rate limits are exceeded.
+- **query_consistency_policy** (String, Optional) JSON representation of the query consistency policy. Controls the consistency mode (Strong/Weak) for queries in this workload group.
+- **cluster** (Optional) `cluster` Configuration block (defined below) for the target cluster (overrides any config specified in the provider)
+
+`cluster` Configuration block for connection details about the target ADX cluster
+
+*Note*: Any attributes specified here override the cluster config specified in the provider. Once a resource overrides an attribute specified in the provider, it will be stored explicitly as state for that resource and will not be possible to go back to the provider config unless explicitly unset.
+
+- **uri** - (String, Optional) Target ADX cluster endpoint URI, starting with `https://`
+- **client_id** - (String, Optional) The client ID for a service principal having admin access to this cluster/database.
+- **client_secret** - (String, Optional) The client secret for a service principal having admin access to this cluster/database
+- **tenant_id** - (String, Optional) Id for the tenant to which the service principal belongs
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- **id** - The ID of this resource.
+
+## Import
+
+Workload groups can be imported using the resource ID format:
+
+```shell
+terraform import adx_workload_group.example <cluster_endpoint>|<database_name>|workload_group|<workload_group_name>
+```


### PR DESCRIPTION

- Add adx_workload_group resource with JSON-based policy management
- Add adx_cluster_request_classification_policy resource
- Add StringIsJSON validator
- Add documentation with import examples for both resources

Tested locally with successfully build provider,